### PR TITLE
Add SimpleAuthPlugin with plain text password storage

### DIFF
--- a/SimpleAuthPlugin/README.md
+++ b/SimpleAuthPlugin/README.md
@@ -1,0 +1,83 @@
+# SimpleAuthPlugin
+
+A simple authentication plugin for Minecraft servers, based on AuthMeReloaded but with plain text password storage.
+
+## Features
+
+- **Authentication System**
+  - Login/register commands
+  - Session management
+  - Plain text password storage
+  - Premium (paid Minecraft) account support
+
+- **Database Support**
+  - MySQL
+  - SQLite
+  - YAML
+
+- **Player Protection**
+  - Movement restriction
+  - Chat restriction
+  - Inventory protection
+  - Command restriction
+  - Damage protection
+
+- **Configuration Options**
+  - Customizable messages
+  - Session timeout
+  - Registration settings
+  - Restriction settings
+
+## Commands
+
+- `/register <password> [email]` - Register an account
+- `/login <password>` - Login to the server
+- `/changepassword <oldPassword> <newPassword>` - Change your password
+- `/logout` - Logout from the server
+- `/unregister <password>` - Unregister your account
+- `/authreload` - Reload the plugin configuration (admin)
+- `/authstatus` - Check the authentication status (admin)
+
+## Installation
+
+1. Download the latest release from the releases page
+2. Place the JAR file in your server's `plugins` folder
+3. Restart the server
+4. Edit the `config.yml` file to customize the plugin
+
+## Configuration
+
+The plugin is highly configurable. You can customize:
+
+- Database type (MySQL, SQLite, YAML)
+- Registration settings
+- Login settings
+- Session settings
+- Spawn settings
+- Restriction settings
+- Messages
+
+## Security Note
+
+This plugin stores passwords in plain text, which is not recommended for production use. This implementation is provided for educational purposes or for servers where security is not a concern.
+
+## Building
+
+To build the plugin:
+
+```bash
+mvn clean package
+```
+
+The compiled JAR file will be in the `target` directory.
+
+## Requirements
+
+- Java 21 or higher
+- Minecraft 1.21.x
+- Paper/Spigot server
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.
+

--- a/SimpleAuthPlugin/pom.xml
+++ b/SimpleAuthPlugin/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.simpleauth</groupId>
+    <artifactId>SimpleAuthPlugin</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>SimpleAuthPlugin</name>
+    <description>A simple authentication plugin for Minecraft servers</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+    </properties>
+
+    <repositories>
+        <!-- Paper repository -->
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <!-- Paper API -->
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        
+        <!-- MySQL Connector -->
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+            <scope>compile</scope>
+        </dependency>
+        
+        <!-- SQLite JDBC -->
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.1.0</version>
+            <scope>compile</scope>
+        </dependency>
+        
+        <!-- HikariCP for connection pooling -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.1.0</version>
+            <scope>compile</scope>
+        </dependency>
+        
+        <!-- SLF4J API -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.12</version>
+            <scope>compile</scope>
+        </dependency>
+        
+        <!-- SLF4J Simple implementation -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.12</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.name}-${project.version}</finalName>
+        <defaultGoal>clean package</defaultGoal>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.zaxxer.hikari</pattern>
+                                    <shadedPattern>com.simpleauth.plugin.libs.hikari</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>com.simpleauth.plugin.libs.slf4j</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/AuthManager.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/AuthManager.java
@@ -331,5 +331,22 @@ public class AuthManager {
     public int getAuthenticatedCount() {
         return authenticatedPlayers.size();
     }
+    
+    /**
+     * Get the data source
+     * 
+     * @return The data source
+     */
+    public AuthDataSource getDataSource() {
+        return dataSource;
+    }
+    
+    /**
+     * Get the session manager
+     * 
+     * @return The session manager
+     */
+    public SessionManager getSessionManager() {
+        return sessionManager;
+    }
 }
-

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/AuthManager.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/AuthManager.java
@@ -1,0 +1,335 @@
+package com.simpleauth.plugin;
+
+import com.simpleauth.plugin.database.AuthDataSource;
+import com.simpleauth.plugin.events.PlayerLoginEvent;
+import com.simpleauth.plugin.events.PlayerLogoutEvent;
+import com.simpleauth.plugin.events.PlayerRegisterEvent;
+import com.simpleauth.plugin.events.PlayerUnregisterEvent;
+import com.simpleauth.plugin.model.PlayerAuth;
+import com.simpleauth.plugin.session.SessionManager;
+import com.simpleauth.plugin.util.LocationUtil;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class AuthManager {
+
+    private final JavaPlugin plugin;
+    private final AuthDataSource dataSource;
+    private final SessionManager sessionManager;
+    private final Set<String> authenticatedPlayers;
+    private final Set<String> registeredPlayers;
+    private final Set<UUID> premiumUuids;
+
+    public AuthManager(JavaPlugin plugin, AuthDataSource dataSource, SessionManager sessionManager) {
+        this.plugin = plugin;
+        this.dataSource = dataSource;
+        this.sessionManager = sessionManager;
+        this.authenticatedPlayers = new HashSet<>();
+        this.registeredPlayers = new HashSet<>();
+        this.premiumUuids = new HashSet<>();
+        
+        // Load registered players into memory for quick access
+        dataSource.getAllPlayers().forEach(auth -> registeredPlayers.add(auth.getUsername().toLowerCase()));
+    }
+
+    /**
+     * Check if a player is registered
+     * 
+     * @param username The player's username
+     * @return True if the player is registered, false otherwise
+     */
+    public boolean isRegistered(String username) {
+        return registeredPlayers.contains(username.toLowerCase());
+    }
+
+    /**
+     * Check if a player is authenticated
+     * 
+     * @param username The player's username
+     * @return True if the player is authenticated, false otherwise
+     */
+    public boolean isAuthenticated(String username) {
+        return authenticatedPlayers.contains(username.toLowerCase());
+    }
+
+    /**
+     * Check if a player is a premium (paid Minecraft) player
+     * 
+     * @param uuid The player's UUID
+     * @return True if the player is premium, false otherwise
+     */
+    public boolean isPremium(UUID uuid) {
+        return premiumUuids.contains(uuid);
+    }
+
+    /**
+     * Register a player
+     * 
+     * @param player The player to register
+     * @param password The player's password (stored in plain text)
+     * @param email The player's email (optional)
+     * @return True if registration was successful, false otherwise
+     */
+    public boolean register(Player player, String password, String email) {
+        String username = player.getName();
+        String lowercaseUsername = username.toLowerCase();
+        
+        // Check if player is already registered
+        if (isRegistered(lowercaseUsername)) {
+            return false;
+        }
+        
+        // Create player auth data
+        PlayerAuth auth = new PlayerAuth(
+            username,
+            lowercaseUsername,
+            password,
+            player.getAddress().getAddress().getHostAddress(),
+            System.currentTimeMillis(),
+            email,
+            player.getLocation()
+        );
+        
+        // Save to database
+        boolean success = dataSource.saveAuth(auth);
+        
+        if (success) {
+            // Add to registered players set
+            registeredPlayers.add(lowercaseUsername);
+            
+            // Call register event
+            PlayerRegisterEvent event = new PlayerRegisterEvent(player);
+            plugin.getServer().getPluginManager().callEvent(event);
+            
+            // Login the player
+            login(player);
+        }
+        
+        return success;
+    }
+
+    /**
+     * Login a player
+     * 
+     * @param player The player to login
+     * @return True if login was successful, false otherwise
+     */
+    public boolean login(Player player) {
+        String username = player.getName();
+        String lowercaseUsername = username.toLowerCase();
+        
+        // Check if player is already authenticated
+        if (isAuthenticated(lowercaseUsername)) {
+            return false;
+        }
+        
+        // Add to authenticated players set
+        authenticatedPlayers.add(lowercaseUsername);
+        
+        // Update last login time and IP
+        PlayerAuth auth = dataSource.getAuth(lowercaseUsername);
+        if (auth != null) {
+            auth.setLastLogin(System.currentTimeMillis());
+            auth.setLastIp(player.getAddress().getAddress().getHostAddress());
+            dataSource.updateAuth(auth);
+        }
+        
+        // Create session
+        sessionManager.createSession(player);
+        
+        // Remove blindness effect if applied
+        if (plugin.getConfig().getBoolean("restrictions.applyBlindness", true)) {
+            player.removePotionEffect(PotionEffectType.BLINDNESS);
+        }
+        
+        // Teleport back to original location if needed
+        if (plugin.getConfig().getBoolean("spawn.teleportBackAfterLogin", true)) {
+            Location originalLocation = LocationUtil.getStoredLocation(plugin, player.getUniqueId());
+            if (originalLocation != null) {
+                player.teleport(originalLocation);
+                LocationUtil.removeStoredLocation(plugin, player.getUniqueId());
+            }
+        }
+        
+        // Call login event
+        PlayerLoginEvent event = new PlayerLoginEvent(player);
+        plugin.getServer().getPluginManager().callEvent(event);
+        
+        return true;
+    }
+
+    /**
+     * Check if a password is correct for a player
+     * 
+     * @param username The player's username
+     * @param password The password to check
+     * @return True if the password is correct, false otherwise
+     */
+    public boolean checkPassword(String username, String password) {
+        PlayerAuth auth = dataSource.getAuth(username.toLowerCase());
+        
+        if (auth == null) {
+            return false;
+        }
+        
+        // Direct plain text comparison
+        return auth.getPassword().equals(password);
+    }
+
+    /**
+     * Change a player's password
+     * 
+     * @param username The player's username
+     * @param newPassword The new password
+     * @return True if the password was changed, false otherwise
+     */
+    public boolean changePassword(String username, String newPassword) {
+        PlayerAuth auth = dataSource.getAuth(username.toLowerCase());
+        
+        if (auth == null) {
+            return false;
+        }
+        
+        // Update password (plain text)
+        auth.setPassword(newPassword);
+        
+        // Save to database
+        return dataSource.updateAuth(auth);
+    }
+
+    /**
+     * Logout a player
+     * 
+     * @param player The player to logout
+     * @return True if logout was successful, false otherwise
+     */
+    public boolean logout(Player player) {
+        String username = player.getName();
+        String lowercaseUsername = username.toLowerCase();
+        
+        // Check if player is authenticated
+        if (!isAuthenticated(lowercaseUsername)) {
+            return false;
+        }
+        
+        // Remove from authenticated players set
+        authenticatedPlayers.remove(lowercaseUsername);
+        
+        // Remove session
+        sessionManager.removeSession(player);
+        
+        // Apply restrictions
+        applyRestrictions(player);
+        
+        // Call logout event
+        PlayerLogoutEvent event = new PlayerLogoutEvent(player);
+        plugin.getServer().getPluginManager().callEvent(event);
+        
+        return true;
+    }
+
+    /**
+     * Unregister a player
+     * 
+     * @param username The player's username
+     * @return True if unregistration was successful, false otherwise
+     */
+    public boolean unregister(String username) {
+        String lowercaseUsername = username.toLowerCase();
+        
+        // Check if player is registered
+        if (!isRegistered(lowercaseUsername)) {
+            return false;
+        }
+        
+        // Remove from database
+        boolean success = dataSource.removeAuth(lowercaseUsername);
+        
+        if (success) {
+            // Remove from registered players set
+            registeredPlayers.remove(lowercaseUsername);
+            
+            // Remove from authenticated players set
+            authenticatedPlayers.remove(lowercaseUsername);
+            
+            // Remove session
+            Player player = plugin.getServer().getPlayer(username);
+            if (player != null && player.isOnline()) {
+                sessionManager.removeSession(player);
+                
+                // Apply restrictions
+                applyRestrictions(player);
+                
+                // Call unregister event
+                PlayerUnregisterEvent event = new PlayerUnregisterEvent(player);
+                plugin.getServer().getPluginManager().callEvent(event);
+            }
+        }
+        
+        return success;
+    }
+
+    /**
+     * Apply restrictions to a player (for unauthenticated players)
+     * 
+     * @param player The player to apply restrictions to
+     */
+    public void applyRestrictions(Player player) {
+        // Apply blindness effect if configured
+        if (plugin.getConfig().getBoolean("restrictions.applyBlindness", true)) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, Integer.MAX_VALUE, 1, false, false));
+        }
+        
+        // Teleport to spawn if configured
+        if (plugin.getConfig().getBoolean("spawn.teleportToSpawn", true)) {
+            // Store original location first
+            LocationUtil.storeLocation(plugin, player.getUniqueId(), player.getLocation());
+            
+            // Teleport to spawn
+            player.teleport(player.getWorld().getSpawnLocation());
+        }
+        
+        // Send login/register message
+        if (isRegistered(player.getName())) {
+            MessageUtil.sendMessage(player, "login");
+        } else {
+            MessageUtil.sendMessage(player, "register");
+        }
+    }
+
+    /**
+     * Mark a player as premium (paid Minecraft account)
+     * 
+     * @param uuid The player's UUID
+     */
+    public void markAsPremium(UUID uuid) {
+        premiumUuids.add(uuid);
+    }
+
+    /**
+     * Get the number of registered players
+     * 
+     * @return The number of registered players
+     */
+    public int getRegisteredCount() {
+        return registeredPlayers.size();
+    }
+
+    /**
+     * Get the number of authenticated players
+     * 
+     * @return The number of authenticated players
+     */
+    public int getAuthenticatedCount() {
+        return authenticatedPlayers.size();
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/AuthManager.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/AuthManager.java
@@ -283,8 +283,8 @@ public class AuthManager {
      * @param player The player to apply restrictions to
      */
     public void applyRestrictions(Player player) {
-        // Apply blindness effect if configured
-        if (plugin.getConfig().getBoolean("restrictions.applyBlindness", true)) {
+        // Apply blindness effect only for login (not for register)
+        if (plugin.getConfig().getBoolean("restrictions.applyBlindness", true) && isRegistered(player.getName())) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, Integer.MAX_VALUE, 1, false, false));
         }
         

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/SimpleAuthPlugin.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/SimpleAuthPlugin.java
@@ -1,0 +1,190 @@
+package com.simpleauth.plugin;
+
+import com.simpleauth.plugin.commands.*;
+import com.simpleauth.plugin.config.ConfigManager;
+import com.simpleauth.plugin.database.AuthDataSource;
+import com.simpleauth.plugin.database.DataSourceType;
+import com.simpleauth.plugin.database.MySQLDataSource;
+import com.simpleauth.plugin.database.SQLiteDataSource;
+import com.simpleauth.plugin.database.YamlDataSource;
+import com.simpleauth.plugin.listeners.PlayerAuthListener;
+import com.simpleauth.plugin.listeners.PlayerProtectionListener;
+import com.simpleauth.plugin.session.SessionManager;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.Objects;
+import java.util.logging.Level;
+
+public class SimpleAuthPlugin extends JavaPlugin {
+
+    private ConfigManager configManager;
+    private AuthDataSource dataSource;
+    private SessionManager sessionManager;
+    private AuthManager authManager;
+
+    @Override
+    public void onEnable() {
+        // Create data folder if it doesn't exist
+        if (!getDataFolder().exists() && !getDataFolder().mkdirs()) {
+            getLogger().severe("Could not create data folder!");
+        }
+
+        // Initialize config
+        saveDefaultConfig();
+        configManager = new ConfigManager(this);
+        configManager.loadConfig();
+
+        // Initialize message utility
+        MessageUtil.init(this);
+
+        // Initialize data source
+        initializeDataSource();
+
+        // Initialize session manager
+        sessionManager = new SessionManager(this, dataSource);
+
+        // Initialize auth manager
+        authManager = new AuthManager(this, dataSource, sessionManager);
+
+        // Register commands
+        registerCommands();
+
+        // Register listeners
+        getServer().getPluginManager().registerEvents(new PlayerAuthListener(this, authManager), this);
+        getServer().getPluginManager().registerEvents(new PlayerProtectionListener(this, authManager), this);
+
+        getLogger().info("SimpleAuthPlugin has been enabled!");
+    }
+
+    @Override
+    public void onDisable() {
+        // Close data source connection
+        if (dataSource != null) {
+            dataSource.close();
+        }
+
+        getLogger().info("SimpleAuthPlugin has been disabled!");
+    }
+
+    private void initializeDataSource() {
+        String dbType = getConfig().getString("database.type", "SQLITE");
+        
+        try {
+            DataSourceType type = DataSourceType.valueOf(dbType.toUpperCase());
+            
+            switch (type) {
+                case MYSQL -> {
+                    String host = getConfig().getString("database.mysql.host", "localhost");
+                    int port = getConfig().getInt("database.mysql.port", 3306);
+                    String database = getConfig().getString("database.mysql.database", "simpleauth");
+                    String username = getConfig().getString("database.mysql.username", "root");
+                    String password = getConfig().getString("database.mysql.password", "");
+                    String tableName = getConfig().getString("database.tableName", "simpleauth");
+                    
+                    dataSource = new MySQLDataSource(this, host, port, database, username, password, tableName);
+                }
+                case SQLITE -> {
+                    String filename = getConfig().getString("database.sqlite.filename", "simpleauth.db");
+                    String tableName = getConfig().getString("database.tableName", "simpleauth");
+                    File databaseFile = new File(getDataFolder(), filename);
+                    
+                    dataSource = new SQLiteDataSource(this, databaseFile, tableName);
+                }
+                case YAML -> {
+                    File dataFile = new File(getDataFolder(), "userdata.yml");
+                    dataSource = new YamlDataSource(this, dataFile);
+                }
+                default -> {
+                    getLogger().warning("Unknown database type: " + dbType + ". Defaulting to SQLite.");
+                    File databaseFile = new File(getDataFolder(), "simpleauth.db");
+                    String tableName = getConfig().getString("database.tableName", "simpleauth");
+                    
+                    dataSource = new SQLiteDataSource(this, databaseFile, tableName);
+                }
+            }
+            
+            // Initialize the data source
+            dataSource.initialize();
+            
+        } catch (Exception e) {
+            getLogger().log(Level.SEVERE, "Failed to initialize data source", e);
+            getServer().getPluginManager().disablePlugin(this);
+        }
+    }
+
+    private void registerCommands() {
+        // Register login command
+        PluginCommand loginCommand = getCommand("login");
+        if (loginCommand != null) {
+            loginCommand.setExecutor(new LoginCommand(this, authManager));
+        }
+
+        // Register register command
+        PluginCommand registerCommand = getCommand("register");
+        if (registerCommand != null) {
+            registerCommand.setExecutor(new RegisterCommand(this, authManager));
+        }
+
+        // Register changepassword command
+        PluginCommand changePasswordCommand = getCommand("changepassword");
+        if (changePasswordCommand != null) {
+            changePasswordCommand.setExecutor(new ChangePasswordCommand(this, authManager));
+        }
+
+        // Register logout command
+        PluginCommand logoutCommand = getCommand("logout");
+        if (logoutCommand != null) {
+            logoutCommand.setExecutor(new LogoutCommand(this, authManager));
+        }
+
+        // Register unregister command
+        PluginCommand unregisterCommand = getCommand("unregister");
+        if (unregisterCommand != null) {
+            unregisterCommand.setExecutor(new UnregisterCommand(this, authManager));
+        }
+
+        // Register authreload command
+        PluginCommand reloadCommand = getCommand("authreload");
+        if (reloadCommand != null) {
+            reloadCommand.setExecutor(new ReloadCommand(this));
+        }
+
+        // Register authstatus command
+        PluginCommand statusCommand = getCommand("authstatus");
+        if (statusCommand != null) {
+            statusCommand.setExecutor(new StatusCommand(this, authManager));
+        }
+    }
+
+    public void reload() {
+        // Reload config
+        reloadConfig();
+        configManager.loadConfig();
+        
+        // Reload message utility
+        MessageUtil.init(this);
+        
+        // Reload session manager
+        sessionManager.reload();
+    }
+
+    public ConfigManager getConfigManager() {
+        return configManager;
+    }
+
+    public AuthDataSource getDataSource() {
+        return dataSource;
+    }
+
+    public SessionManager getSessionManager() {
+        return sessionManager;
+    }
+
+    public AuthManager getAuthManager() {
+        return authManager;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/ChangePasswordCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/ChangePasswordCommand.java
@@ -1,0 +1,87 @@
+package com.simpleauth.plugin.commands;
+
+import com.simpleauth.plugin.AuthManager;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Command for changing password
+ */
+public class ChangePasswordCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+    private final AuthManager authManager;
+
+    /**
+     * Constructor for ChangePasswordCommand
+     * 
+     * @param plugin The plugin instance
+     * @param authManager The auth manager
+     */
+    public ChangePasswordCommand(JavaPlugin plugin, AuthManager authManager) {
+        this.plugin = plugin;
+        this.authManager = authManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            MessageUtil.sendRawMessage((Player) sender, "&cOnly players can use this command!");
+            return true;
+        }
+        
+        // Check if player is authenticated
+        if (!authManager.isAuthenticated(player.getName())) {
+            MessageUtil.sendMessage(player, "notLoggedIn");
+            return true;
+        }
+        
+        // Check if player is registered
+        if (!authManager.isRegistered(player.getName())) {
+            MessageUtil.sendMessage(player, "notRegistered");
+            return true;
+        }
+        
+        // Check if old and new passwords are provided
+        if (args.length < 2) {
+            MessageUtil.sendRawMessage(player, "&cUsage: /changepassword <oldPassword> <newPassword>");
+            return true;
+        }
+        
+        String oldPassword = args[0];
+        String newPassword = args[1];
+        
+        // Check if old password is correct
+        if (!authManager.checkPassword(player.getName(), oldPassword)) {
+            MessageUtil.sendRawMessage(player, "&cOld password is incorrect!");
+            return true;
+        }
+        
+        // Check new password length
+        int minLength = plugin.getConfig().getInt("registration.minPasswordLength", 4);
+        int maxLength = plugin.getConfig().getInt("registration.maxPasswordLength", 30);
+        
+        if (newPassword.length() < minLength) {
+            MessageUtil.sendRawMessage(player, "&cNew password is too short! Minimum length is " + minLength + " characters.");
+            return true;
+        }
+        
+        if (newPassword.length() > maxLength) {
+            MessageUtil.sendRawMessage(player, "&cNew password is too long! Maximum length is " + maxLength + " characters.");
+            return true;
+        }
+        
+        // Change the password
+        if (authManager.changePassword(player.getName(), newPassword)) {
+            MessageUtil.sendMessage(player, "passwordChanged");
+        } else {
+            MessageUtil.sendRawMessage(player, "&cFailed to change password! Please try again later.");
+        }
+        
+        return true;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/LoginCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/LoginCommand.java
@@ -59,7 +59,8 @@ public class LoginCommand implements CommandExecutor {
             
             // Kick player if configured
             if (plugin.getConfig().getBoolean("login.kickOnWrongPassword", true)) {
-                player.kickPlayer(MessageUtil.formatMessage(plugin.getConfig().getString("login.wrongPasswordMessage", "Wrong password!")));
+                String kickMessage = MessageUtil.formatMessage(plugin.getConfig().getString("login.wrongPasswordMessage", "Wrong password!"));
+                player.kick(net.kyori.adventure.text.Component.text(kickMessage));
             }
             
             return true;
@@ -73,4 +74,3 @@ public class LoginCommand implements CommandExecutor {
         return true;
     }
 }
-

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/LoginCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/LoginCommand.java
@@ -55,11 +55,11 @@ public class LoginCommand implements CommandExecutor {
         
         // Check if password is correct
         if (!authManager.checkPassword(player.getName(), password)) {
-            MessageUtil.sendMessage(player, "wrongPasswordMessage");
+            MessageUtil.sendMessage(player, "wrongPassword");
             
             // Kick player if configured
             if (plugin.getConfig().getBoolean("login.kickOnWrongPassword", true)) {
-                String kickMessage = MessageUtil.formatMessage(plugin.getConfig().getString("login.wrongPasswordMessage", "Wrong password!"));
+                String kickMessage = MessageUtil.formatMessage(plugin.getConfig().getString("messages.wrongPassword", "&cWrong password!"));
                 player.kick(net.kyori.adventure.text.Component.text(kickMessage));
             }
             

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/LoginCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/LoginCommand.java
@@ -1,0 +1,76 @@
+package com.simpleauth.plugin.commands;
+
+import com.simpleauth.plugin.AuthManager;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Command for logging in
+ */
+public class LoginCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+    private final AuthManager authManager;
+
+    /**
+     * Constructor for LoginCommand
+     * 
+     * @param plugin The plugin instance
+     * @param authManager The auth manager
+     */
+    public LoginCommand(JavaPlugin plugin, AuthManager authManager) {
+        this.plugin = plugin;
+        this.authManager = authManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            MessageUtil.sendRawMessage((Player) sender, "&cOnly players can use this command!");
+            return true;
+        }
+        
+        // Check if player is already authenticated
+        if (authManager.isAuthenticated(player.getName())) {
+            MessageUtil.sendMessage(player, "alreadyLoggedIn");
+            return true;
+        }
+        
+        // Check if player is registered
+        if (!authManager.isRegistered(player.getName())) {
+            MessageUtil.sendMessage(player, "notRegistered");
+            return true;
+        }
+        
+        // Check if password is provided
+        if (args.length < 1) {
+            MessageUtil.sendRawMessage(player, "&cUsage: /login <password>");
+            return true;
+        }
+        
+        String password = args[0];
+        
+        // Check if password is correct
+        if (!authManager.checkPassword(player.getName(), password)) {
+            MessageUtil.sendMessage(player, "wrongPasswordMessage");
+            
+            // Kick player if configured
+            if (plugin.getConfig().getBoolean("login.kickOnWrongPassword", true)) {
+                player.kickPlayer(MessageUtil.formatMessage(plugin.getConfig().getString("login.wrongPasswordMessage", "Wrong password!")));
+            }
+            
+            return true;
+        }
+        
+        // Login the player
+        if (authManager.login(player)) {
+            MessageUtil.sendMessage(player, "loginSuccess");
+        }
+        
+        return true;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/LogoutCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/LogoutCommand.java
@@ -1,0 +1,52 @@
+package com.simpleauth.plugin.commands;
+
+import com.simpleauth.plugin.AuthManager;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Command for logging out
+ */
+public class LogoutCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+    private final AuthManager authManager;
+
+    /**
+     * Constructor for LogoutCommand
+     * 
+     * @param plugin The plugin instance
+     * @param authManager The auth manager
+     */
+    public LogoutCommand(JavaPlugin plugin, AuthManager authManager) {
+        this.plugin = plugin;
+        this.authManager = authManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            MessageUtil.sendRawMessage((Player) sender, "&cOnly players can use this command!");
+            return true;
+        }
+        
+        // Check if player is authenticated
+        if (!authManager.isAuthenticated(player.getName())) {
+            MessageUtil.sendMessage(player, "notLoggedIn");
+            return true;
+        }
+        
+        // Logout the player
+        if (authManager.logout(player)) {
+            MessageUtil.sendMessage(player, "loggedOut");
+        } else {
+            MessageUtil.sendRawMessage(player, "&cFailed to logout! Please try again later.");
+        }
+        
+        return true;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/RegisterCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/RegisterCommand.java
@@ -56,7 +56,7 @@ public class RegisterCommand implements CommandExecutor {
         
         // Check if email is required
         if (plugin.getConfig().getBoolean("registration.requireEmail", false) && email == null) {
-            MessageUtil.sendRawMessage(player, "&cYou must provide an email address!");
+            MessageUtil.sendMessage(player, "emailRequired");
             return true;
         }
         
@@ -65,12 +65,12 @@ public class RegisterCommand implements CommandExecutor {
         int maxLength = plugin.getConfig().getInt("registration.maxPasswordLength", 30);
         
         if (password.length() < minLength) {
-            MessageUtil.sendRawMessage(player, "&cPassword is too short! Minimum length is " + minLength + " characters.");
+            MessageUtil.sendMessage(player, "passwordTooShort");
             return true;
         }
         
         if (password.length() > maxLength) {
-            MessageUtil.sendRawMessage(player, "&cPassword is too long! Maximum length is " + maxLength + " characters.");
+            MessageUtil.sendMessage(player, "passwordTooLong");
             return true;
         }
         
@@ -81,7 +81,7 @@ public class RegisterCommand implements CommandExecutor {
             int accountsForIp = authManager.getDataSource().countAccountsForIp(ip);
             
             if (accountsForIp >= maxAccountsPerIp) {
-                MessageUtil.sendRawMessage(player, "&cYou have reached the maximum number of accounts per IP!");
+                MessageUtil.sendMessage(player, "tooManyAccounts");
                 return true;
             }
         }
@@ -96,4 +96,3 @@ public class RegisterCommand implements CommandExecutor {
         return true;
     }
 }
-

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/RegisterCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/RegisterCommand.java
@@ -1,0 +1,99 @@
+package com.simpleauth.plugin.commands;
+
+import com.simpleauth.plugin.AuthManager;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Command for registering
+ */
+public class RegisterCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+    private final AuthManager authManager;
+
+    /**
+     * Constructor for RegisterCommand
+     * 
+     * @param plugin The plugin instance
+     * @param authManager The auth manager
+     */
+    public RegisterCommand(JavaPlugin plugin, AuthManager authManager) {
+        this.plugin = plugin;
+        this.authManager = authManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            MessageUtil.sendRawMessage((Player) sender, "&cOnly players can use this command!");
+            return true;
+        }
+        
+        // Check if player is already registered
+        if (authManager.isRegistered(player.getName())) {
+            MessageUtil.sendMessage(player, "alreadyRegistered");
+            return true;
+        }
+        
+        // Check if registration is enabled
+        if (!plugin.getConfig().getBoolean("registration.enabled", true)) {
+            MessageUtil.sendRawMessage(player, "&cRegistration is disabled!");
+            return true;
+        }
+        
+        // Check if password is provided
+        if (args.length < 1) {
+            MessageUtil.sendRawMessage(player, "&cUsage: /register <password> [email]");
+            return true;
+        }
+        
+        String password = args[0];
+        String email = args.length > 1 ? args[1] : null;
+        
+        // Check if email is required
+        if (plugin.getConfig().getBoolean("registration.requireEmail", false) && email == null) {
+            MessageUtil.sendRawMessage(player, "&cYou must provide an email address!");
+            return true;
+        }
+        
+        // Check password length
+        int minLength = plugin.getConfig().getInt("registration.minPasswordLength", 4);
+        int maxLength = plugin.getConfig().getInt("registration.maxPasswordLength", 30);
+        
+        if (password.length() < minLength) {
+            MessageUtil.sendRawMessage(player, "&cPassword is too short! Minimum length is " + minLength + " characters.");
+            return true;
+        }
+        
+        if (password.length() > maxLength) {
+            MessageUtil.sendRawMessage(player, "&cPassword is too long! Maximum length is " + maxLength + " characters.");
+            return true;
+        }
+        
+        // Check max accounts per IP
+        int maxAccountsPerIp = plugin.getConfig().getInt("registration.maxAccountsPerIp", 3);
+        if (maxAccountsPerIp > 0) {
+            String ip = player.getAddress().getAddress().getHostAddress();
+            int accountsForIp = authManager.getDataSource().countAccountsForIp(ip);
+            
+            if (accountsForIp >= maxAccountsPerIp) {
+                MessageUtil.sendRawMessage(player, "&cYou have reached the maximum number of accounts per IP!");
+                return true;
+            }
+        }
+        
+        // Register the player
+        if (authManager.register(player, password, email)) {
+            MessageUtil.sendMessage(player, "registerSuccess");
+        } else {
+            MessageUtil.sendRawMessage(player, "&cFailed to register! Please try again later.");
+        }
+        
+        return true;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/ReloadCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/ReloadCommand.java
@@ -1,0 +1,51 @@
+package com.simpleauth.plugin.commands;
+
+import com.simpleauth.plugin.SimpleAuthPlugin;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Command for reloading the plugin
+ */
+public class ReloadCommand implements CommandExecutor {
+    private final SimpleAuthPlugin plugin;
+
+    /**
+     * Constructor for ReloadCommand
+     * 
+     * @param plugin The plugin instance
+     */
+    public ReloadCommand(SimpleAuthPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        // Check if sender has permission
+        if (!sender.hasPermission("simpleauth.admin.reload")) {
+            if (sender instanceof Player player) {
+                MessageUtil.sendRawMessage(player, "&cYou don't have permission to use this command!");
+            } else {
+                sender.sendMessage("You don't have permission to use this command!");
+            }
+            return true;
+        }
+        
+        // Reload the plugin
+        plugin.reload();
+        
+        // Send success message
+        if (sender instanceof Player player) {
+            MessageUtil.sendMessage(player, "reloaded");
+        } else {
+            sender.sendMessage("SimpleAuthPlugin has been reloaded!");
+        }
+        
+        return true;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/StatusCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/StatusCommand.java
@@ -1,0 +1,64 @@
+package com.simpleauth.plugin.commands;
+
+import com.simpleauth.plugin.AuthManager;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Command for checking the authentication status
+ */
+public class StatusCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+    private final AuthManager authManager;
+
+    /**
+     * Constructor for StatusCommand
+     * 
+     * @param plugin The plugin instance
+     * @param authManager The auth manager
+     */
+    public StatusCommand(JavaPlugin plugin, AuthManager authManager) {
+        this.plugin = plugin;
+        this.authManager = authManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        // Check if sender has permission
+        if (!sender.hasPermission("simpleauth.admin.status")) {
+            if (sender instanceof Player player) {
+                MessageUtil.sendRawMessage(player, "&cYou don't have permission to use this command!");
+            } else {
+                sender.sendMessage("You don't have permission to use this command!");
+            }
+            return true;
+        }
+        
+        // Get status information
+        int registeredCount = authManager.getRegisteredCount();
+        int authenticatedCount = authManager.getAuthenticatedCount();
+        int onlineCount = plugin.getServer().getOnlinePlayers().size();
+        
+        // Send status information
+        if (sender instanceof Player player) {
+            MessageUtil.sendRawMessage(player, "&6=== SimpleAuth Status ===");
+            MessageUtil.sendRawMessage(player, "&7Registered players: &f" + registeredCount);
+            MessageUtil.sendRawMessage(player, "&7Authenticated players: &f" + authenticatedCount + "&7/&f" + onlineCount);
+            MessageUtil.sendRawMessage(player, "&7Database type: &f" + plugin.getConfig().getString("database.type", "SQLITE"));
+            MessageUtil.sendRawMessage(player, "&7Session timeout: &f" + plugin.getConfig().getLong("session.timeout", 60) + " minutes");
+        } else {
+            sender.sendMessage("=== SimpleAuth Status ===");
+            sender.sendMessage("Registered players: " + registeredCount);
+            sender.sendMessage("Authenticated players: " + authenticatedCount + "/" + onlineCount);
+            sender.sendMessage("Database type: " + plugin.getConfig().getString("database.type", "SQLITE"));
+            sender.sendMessage("Session timeout: " + plugin.getConfig().getLong("session.timeout", 60) + " minutes");
+        }
+        
+        return true;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/UnregisterCommand.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/commands/UnregisterCommand.java
@@ -1,0 +1,89 @@
+package com.simpleauth.plugin.commands;
+
+import com.simpleauth.plugin.AuthManager;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Command for unregistering
+ */
+public class UnregisterCommand implements CommandExecutor {
+    private final JavaPlugin plugin;
+    private final AuthManager authManager;
+
+    /**
+     * Constructor for UnregisterCommand
+     * 
+     * @param plugin The plugin instance
+     * @param authManager The auth manager
+     */
+    public UnregisterCommand(JavaPlugin plugin, AuthManager authManager) {
+        this.plugin = plugin;
+        this.authManager = authManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        // Check if sender is a player or console
+        if (sender instanceof Player player) {
+            // Player is unregistering themselves
+            
+            // Check if player is registered
+            if (!authManager.isRegistered(player.getName())) {
+                MessageUtil.sendMessage(player, "notRegistered");
+                return true;
+            }
+            
+            // Check if password is provided
+            if (args.length < 1) {
+                MessageUtil.sendRawMessage(player, "&cUsage: /unregister <password>");
+                return true;
+            }
+            
+            String password = args[0];
+            
+            // Check if password is correct
+            if (!authManager.checkPassword(player.getName(), password)) {
+                MessageUtil.sendRawMessage(player, "&cIncorrect password!");
+                return true;
+            }
+            
+            // Unregister the player
+            if (authManager.unregister(player.getName())) {
+                MessageUtil.sendMessage(player, "unregistered");
+            } else {
+                MessageUtil.sendRawMessage(player, "&cFailed to unregister! Please try again later.");
+            }
+        } else {
+            // Console is unregistering a player
+            
+            // Check if player name is provided
+            if (args.length < 1) {
+                sender.sendMessage("Usage: /unregister <player>");
+                return true;
+            }
+            
+            String playerName = args[0];
+            
+            // Check if player is registered
+            if (!authManager.isRegistered(playerName)) {
+                sender.sendMessage("Player " + playerName + " is not registered!");
+                return true;
+            }
+            
+            // Unregister the player
+            if (authManager.unregister(playerName)) {
+                sender.sendMessage("Player " + playerName + " has been unregistered!");
+            } else {
+                sender.sendMessage("Failed to unregister player " + playerName + "! Please try again later.");
+            }
+        }
+        
+        return true;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/config/ConfigManager.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/config/ConfigManager.java
@@ -1,0 +1,329 @@
+package com.simpleauth.plugin.config;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Manages the plugin configuration
+ */
+public class ConfigManager {
+    private final JavaPlugin plugin;
+    
+    private boolean registrationEnabled;
+    private boolean registrationForced;
+    private int maxAccountsPerIp;
+    private int minPasswordLength;
+    private int maxPasswordLength;
+    private boolean requireEmail;
+    private boolean verifyEmail;
+    
+    private int maxLoginAttempts;
+    private int loginTimeout;
+    private boolean kickOnWrongPassword;
+    private String wrongPasswordMessage;
+    
+    private boolean sessionEnabled;
+    private long sessionTimeout;
+    private boolean sessionValidateIp;
+    
+    private boolean teleportToSpawn;
+    private boolean teleportBackAfterLogin;
+    private boolean useFirstSpawn;
+    
+    private boolean allowChat;
+    private boolean hideChat;
+    private boolean allowMovement;
+    private double allowedMovementRadius;
+    private boolean protectInventory;
+    private boolean forceSurvivalMode;
+    private boolean applyBlindness;
+    
+    private boolean premiumEnabled;
+    private boolean premiumForceUsername;
+
+    /**
+     * Constructor for ConfigManager
+     * 
+     * @param plugin The plugin instance
+     */
+    public ConfigManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Load the configuration
+     */
+    public void loadConfig() {
+        // Registration settings
+        registrationEnabled = plugin.getConfig().getBoolean("registration.enabled", true);
+        registrationForced = plugin.getConfig().getBoolean("registration.forced", true);
+        maxAccountsPerIp = plugin.getConfig().getInt("registration.maxAccountsPerIp", 3);
+        minPasswordLength = plugin.getConfig().getInt("registration.minPasswordLength", 4);
+        maxPasswordLength = plugin.getConfig().getInt("registration.maxPasswordLength", 30);
+        requireEmail = plugin.getConfig().getBoolean("registration.requireEmail", false);
+        verifyEmail = plugin.getConfig().getBoolean("registration.verifyEmail", false);
+        
+        // Login settings
+        maxLoginAttempts = plugin.getConfig().getInt("login.maxLoginAttempts", 5);
+        loginTimeout = plugin.getConfig().getInt("login.loginTimeout", 300);
+        kickOnWrongPassword = plugin.getConfig().getBoolean("login.kickOnWrongPassword", true);
+        wrongPasswordMessage = plugin.getConfig().getString("login.wrongPasswordMessage", "Wrong password!");
+        
+        // Session settings
+        sessionEnabled = plugin.getConfig().getBoolean("session.enabled", true);
+        sessionTimeout = plugin.getConfig().getLong("session.timeout", 60);
+        sessionValidateIp = plugin.getConfig().getBoolean("session.validateIp", true);
+        
+        // Spawn settings
+        teleportToSpawn = plugin.getConfig().getBoolean("spawn.teleportToSpawn", true);
+        teleportBackAfterLogin = plugin.getConfig().getBoolean("spawn.teleportBackAfterLogin", true);
+        useFirstSpawn = plugin.getConfig().getBoolean("spawn.useFirstSpawn", false);
+        
+        // Restriction settings
+        allowChat = plugin.getConfig().getBoolean("restrictions.allowChat", false);
+        hideChat = plugin.getConfig().getBoolean("restrictions.hideChat", true);
+        allowMovement = plugin.getConfig().getBoolean("restrictions.allowMovement", false);
+        allowedMovementRadius = plugin.getConfig().getDouble("restrictions.allowedMovementRadius", 100);
+        protectInventory = plugin.getConfig().getBoolean("restrictions.protectInventory", true);
+        forceSurvivalMode = plugin.getConfig().getBoolean("restrictions.forceSurvivalMode", true);
+        applyBlindness = plugin.getConfig().getBoolean("restrictions.applyBlindness", true);
+        
+        // Premium settings
+        premiumEnabled = plugin.getConfig().getBoolean("premium.enabled", true);
+        premiumForceUsername = plugin.getConfig().getBoolean("premium.forceUsername", true);
+    }
+
+    /**
+     * Check if registration is enabled
+     * 
+     * @return True if registration is enabled, false otherwise
+     */
+    public boolean isRegistrationEnabled() {
+        return registrationEnabled;
+    }
+
+    /**
+     * Check if registration is forced
+     * 
+     * @return True if registration is forced, false otherwise
+     */
+    public boolean isRegistrationForced() {
+        return registrationForced;
+    }
+
+    /**
+     * Get the maximum number of accounts per IP
+     * 
+     * @return The maximum number of accounts per IP
+     */
+    public int getMaxAccountsPerIp() {
+        return maxAccountsPerIp;
+    }
+
+    /**
+     * Get the minimum password length
+     * 
+     * @return The minimum password length
+     */
+    public int getMinPasswordLength() {
+        return minPasswordLength;
+    }
+
+    /**
+     * Get the maximum password length
+     * 
+     * @return The maximum password length
+     */
+    public int getMaxPasswordLength() {
+        return maxPasswordLength;
+    }
+
+    /**
+     * Check if email is required for registration
+     * 
+     * @return True if email is required, false otherwise
+     */
+    public boolean isRequireEmail() {
+        return requireEmail;
+    }
+
+    /**
+     * Check if email verification is enabled
+     * 
+     * @return True if email verification is enabled, false otherwise
+     */
+    public boolean isVerifyEmail() {
+        return verifyEmail;
+    }
+
+    /**
+     * Get the maximum number of login attempts
+     * 
+     * @return The maximum number of login attempts
+     */
+    public int getMaxLoginAttempts() {
+        return maxLoginAttempts;
+    }
+
+    /**
+     * Get the login timeout in seconds
+     * 
+     * @return The login timeout in seconds
+     */
+    public int getLoginTimeout() {
+        return loginTimeout;
+    }
+
+    /**
+     * Check if players should be kicked on wrong password
+     * 
+     * @return True if players should be kicked on wrong password, false otherwise
+     */
+    public boolean isKickOnWrongPassword() {
+        return kickOnWrongPassword;
+    }
+
+    /**
+     * Get the wrong password message
+     * 
+     * @return The wrong password message
+     */
+    public String getWrongPasswordMessage() {
+        return wrongPasswordMessage;
+    }
+
+    /**
+     * Check if sessions are enabled
+     * 
+     * @return True if sessions are enabled, false otherwise
+     */
+    public boolean isSessionEnabled() {
+        return sessionEnabled;
+    }
+
+    /**
+     * Get the session timeout in minutes
+     * 
+     * @return The session timeout in minutes
+     */
+    public long getSessionTimeout() {
+        return sessionTimeout;
+    }
+
+    /**
+     * Check if IP validation is enabled for sessions
+     * 
+     * @return True if IP validation is enabled, false otherwise
+     */
+    public boolean isSessionValidateIp() {
+        return sessionValidateIp;
+    }
+
+    /**
+     * Check if teleportation to spawn is enabled
+     * 
+     * @return True if teleportation to spawn is enabled, false otherwise
+     */
+    public boolean isTeleportToSpawn() {
+        return teleportToSpawn;
+    }
+
+    /**
+     * Check if teleportation back after login is enabled
+     * 
+     * @return True if teleportation back after login is enabled, false otherwise
+     */
+    public boolean isTeleportBackAfterLogin() {
+        return teleportBackAfterLogin;
+    }
+
+    /**
+     * Check if first spawn is enabled
+     * 
+     * @return True if first spawn is enabled, false otherwise
+     */
+    public boolean isUseFirstSpawn() {
+        return useFirstSpawn;
+    }
+
+    /**
+     * Check if chat is allowed for unauthenticated players
+     * 
+     * @return True if chat is allowed, false otherwise
+     */
+    public boolean isAllowChat() {
+        return allowChat;
+    }
+
+    /**
+     * Check if chat should be hidden for unauthenticated players
+     * 
+     * @return True if chat should be hidden, false otherwise
+     */
+    public boolean isHideChat() {
+        return hideChat;
+    }
+
+    /**
+     * Check if movement is allowed for unauthenticated players
+     * 
+     * @return True if movement is allowed, false otherwise
+     */
+    public boolean isAllowMovement() {
+        return allowMovement;
+    }
+
+    /**
+     * Get the allowed movement radius
+     * 
+     * @return The allowed movement radius
+     */
+    public double getAllowedMovementRadius() {
+        return allowedMovementRadius;
+    }
+
+    /**
+     * Check if inventory protection is enabled
+     * 
+     * @return True if inventory protection is enabled, false otherwise
+     */
+    public boolean isProtectInventory() {
+        return protectInventory;
+    }
+
+    /**
+     * Check if survival mode should be forced
+     * 
+     * @return True if survival mode should be forced, false otherwise
+     */
+    public boolean isForceSurvivalMode() {
+        return forceSurvivalMode;
+    }
+
+    /**
+     * Check if blindness effect should be applied
+     * 
+     * @return True if blindness effect should be applied, false otherwise
+     */
+    public boolean isApplyBlindness() {
+        return applyBlindness;
+    }
+
+    /**
+     * Check if premium (paid Minecraft) account support is enabled
+     * 
+     * @return True if premium account support is enabled, false otherwise
+     */
+    public boolean isPremiumEnabled() {
+        return premiumEnabled;
+    }
+
+    /**
+     * Check if premium users should be forced to use their Minecraft username
+     * 
+     * @return True if premium users should be forced to use their Minecraft username, false otherwise
+     */
+    public boolean isPremiumForceUsername() {
+        return premiumForceUsername;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/AuthDataSource.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/AuthDataSource.java
@@ -1,0 +1,93 @@
+package com.simpleauth.plugin.database;
+
+import com.simpleauth.plugin.model.PlayerAuth;
+
+import java.util.List;
+
+/**
+ * Interface for authentication data sources
+ */
+public interface AuthDataSource {
+
+    /**
+     * Initialize the data source
+     */
+    void initialize();
+
+    /**
+     * Close the data source
+     */
+    void close();
+
+    /**
+     * Get a player's authentication data
+     * 
+     * @param username The player's username
+     * @return The player's authentication data, or null if not found
+     */
+    PlayerAuth getAuth(String username);
+
+    /**
+     * Save a player's authentication data
+     * 
+     * @param auth The player's authentication data
+     * @return True if the save was successful, false otherwise
+     */
+    boolean saveAuth(PlayerAuth auth);
+
+    /**
+     * Update a player's authentication data
+     * 
+     * @param auth The player's authentication data
+     * @return True if the update was successful, false otherwise
+     */
+    boolean updateAuth(PlayerAuth auth);
+
+    /**
+     * Remove a player's authentication data
+     * 
+     * @param username The player's username
+     * @return True if the removal was successful, false otherwise
+     */
+    boolean removeAuth(String username);
+
+    /**
+     * Check if a player is registered
+     * 
+     * @param username The player's username
+     * @return True if the player is registered, false otherwise
+     */
+    boolean isAuthAvailable(String username);
+
+    /**
+     * Get all registered players
+     * 
+     * @return A list of all registered players
+     */
+    List<PlayerAuth> getAllPlayers();
+
+    /**
+     * Get the number of registered accounts for an IP address
+     * 
+     * @param ip The IP address
+     * @return The number of registered accounts
+     */
+    int countAccountsForIp(String ip);
+
+    /**
+     * Get all registered accounts for an IP address
+     * 
+     * @param ip The IP address
+     * @return A list of usernames registered with the IP address
+     */
+    List<String> getAccountsForIp(String ip);
+
+    /**
+     * Purge old data
+     * 
+     * @param days The number of days of inactivity before purging
+     * @return The number of accounts purged
+     */
+    int purgeOldData(int days);
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/DataSourceType.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/DataSourceType.java
@@ -1,0 +1,11 @@
+package com.simpleauth.plugin.database;
+
+/**
+ * Enum representing the different types of data sources
+ */
+public enum DataSourceType {
+    MYSQL,
+    SQLITE,
+    YAML
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/MySQLDataSource.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/MySQLDataSource.java
@@ -1,0 +1,422 @@
+package com.simpleauth.plugin.database;
+
+import com.simpleauth.plugin.model.PlayerAuth;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.bukkit.Location;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ * MySQL implementation of the AuthDataSource interface
+ */
+public class MySQLDataSource implements AuthDataSource {
+    private final JavaPlugin plugin;
+    private final String host;
+    private final int port;
+    private final String database;
+    private final String username;
+    private final String password;
+    private final String tableName;
+    private HikariDataSource dataSource;
+
+    /**
+     * Constructor for MySQLDataSource
+     * 
+     * @param plugin The plugin instance
+     * @param host The MySQL host
+     * @param port The MySQL port
+     * @param database The MySQL database
+     * @param username The MySQL username
+     * @param password The MySQL password
+     * @param tableName The table name
+     */
+    public MySQLDataSource(JavaPlugin plugin, String host, int port, String database, 
+                          String username, String password, String tableName) {
+        this.plugin = plugin;
+        this.host = host;
+        this.port = port;
+        this.database = database;
+        this.username = username;
+        this.password = password;
+        this.tableName = tableName;
+    }
+
+    @Override
+    public void initialize() {
+        try {
+            // Configure HikariCP
+            HikariConfig config = new HikariConfig();
+            config.setJdbcUrl(String.format("jdbc:mysql://%s:%d/%s", host, port, database));
+            config.setUsername(username);
+            config.setPassword(password);
+            config.setMaximumPoolSize(plugin.getConfig().getInt("database.mysql.pool.maxPoolSize", 10));
+            config.setMinimumIdle(plugin.getConfig().getInt("database.mysql.pool.minIdle", 5));
+            config.setMaxLifetime(plugin.getConfig().getLong("database.mysql.pool.maxLifetime", 1800000));
+            config.setConnectionTimeout(plugin.getConfig().getLong("database.mysql.pool.connectionTimeout", 5000));
+            config.addDataSourceProperty("cachePrepStmts", "true");
+            config.addDataSourceProperty("prepStmtCacheSize", "250");
+            config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+
+            // Create the connection pool
+            dataSource = new HikariDataSource(config);
+
+            // Create table if it doesn't exist
+            createTable();
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not initialize MySQL connection", e);
+        }
+    }
+
+    private void createTable() {
+        String sql = "CREATE TABLE IF NOT EXISTS " + tableName + " ("
+            + "username VARCHAR(16) NOT NULL PRIMARY KEY, "
+            + "realname VARCHAR(16) NOT NULL, "
+            + "password VARCHAR(255) NOT NULL, "
+            + "ip VARCHAR(40) NOT NULL, "
+            + "lastlogin BIGINT NOT NULL, "
+            + "email VARCHAR(255), "
+            + "x DOUBLE DEFAULT 0, "
+            + "y DOUBLE DEFAULT 0, "
+            + "z DOUBLE DEFAULT 0, "
+            + "world VARCHAR(255) DEFAULT 'world', "
+            + "yaw FLOAT DEFAULT 0, "
+            + "pitch FLOAT DEFAULT 0, "
+            + "quitx DOUBLE DEFAULT 0, "
+            + "quity DOUBLE DEFAULT 0, "
+            + "quitz DOUBLE DEFAULT 0, "
+            + "quitworld VARCHAR(255) DEFAULT 'world', "
+            + "quityaw FLOAT DEFAULT 0, "
+            + "quitpitch FLOAT DEFAULT 0"
+            + ") CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate(sql);
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not create auth table", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (dataSource != null && !dataSource.isClosed()) {
+            dataSource.close();
+        }
+    }
+
+    @Override
+    public PlayerAuth getAuth(String username) {
+        String sql = "SELECT * FROM " + tableName + " WHERE username = ? LIMIT 1";
+        
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            
+            stmt.setString(1, username.toLowerCase());
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    Location loc = new Location(
+                        plugin.getServer().getWorld(rs.getString("world")),
+                        rs.getDouble("x"),
+                        rs.getDouble("y"),
+                        rs.getDouble("z"),
+                        rs.getFloat("yaw"),
+                        rs.getFloat("pitch")
+                    );
+                    
+                    Location quitLoc = new Location(
+                        plugin.getServer().getWorld(rs.getString("quitworld")),
+                        rs.getDouble("quitx"),
+                        rs.getDouble("quity"),
+                        rs.getDouble("quitz"),
+                        rs.getFloat("quityaw"),
+                        rs.getFloat("quitpitch")
+                    );
+                    
+                    PlayerAuth auth = new PlayerAuth(
+                        rs.getString("realname"),
+                        rs.getString("username"),
+                        rs.getString("password"),
+                        rs.getString("ip"),
+                        rs.getLong("lastlogin"),
+                        rs.getString("email"),
+                        loc
+                    );
+                    
+                    auth.setQuitLocation(quitLoc);
+                    
+                    return auth;
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not get auth data for " + username, e);
+        }
+        
+        return null;
+    }
+
+    @Override
+    public boolean saveAuth(PlayerAuth auth) {
+        String sql = "INSERT INTO " + tableName + " (username, realname, password, ip, lastlogin, "
+            + "email, x, y, z, world, yaw, pitch, quitx, quity, quitz, quitworld, quityaw, quitpitch) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            
+            stmt.setString(1, auth.getUsername().toLowerCase());
+            stmt.setString(2, auth.getRealName());
+            stmt.setString(3, auth.getPassword());
+            stmt.setString(4, auth.getLastIp());
+            stmt.setLong(5, auth.getLastLogin());
+            stmt.setString(6, auth.getEmail());
+            
+            Location loc = auth.getLastLocation();
+            if (loc != null && loc.getWorld() != null) {
+                stmt.setDouble(7, loc.getX());
+                stmt.setDouble(8, loc.getY());
+                stmt.setDouble(9, loc.getZ());
+                stmt.setString(10, loc.getWorld().getName());
+                stmt.setFloat(11, loc.getYaw());
+                stmt.setFloat(12, loc.getPitch());
+            } else {
+                stmt.setDouble(7, 0);
+                stmt.setDouble(8, 0);
+                stmt.setDouble(9, 0);
+                stmt.setString(10, "world");
+                stmt.setFloat(11, 0);
+                stmt.setFloat(12, 0);
+            }
+            
+            Location quitLoc = auth.getQuitLocation();
+            if (quitLoc != null && quitLoc.getWorld() != null) {
+                stmt.setDouble(13, quitLoc.getX());
+                stmt.setDouble(14, quitLoc.getY());
+                stmt.setDouble(15, quitLoc.getZ());
+                stmt.setString(16, quitLoc.getWorld().getName());
+                stmt.setFloat(17, quitLoc.getYaw());
+                stmt.setFloat(18, quitLoc.getPitch());
+            } else {
+                stmt.setDouble(13, 0);
+                stmt.setDouble(14, 0);
+                stmt.setDouble(15, 0);
+                stmt.setString(16, "world");
+                stmt.setFloat(17, 0);
+                stmt.setFloat(18, 0);
+            }
+            
+            return stmt.executeUpdate() > 0;
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not save auth data for " + auth.getUsername(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean updateAuth(PlayerAuth auth) {
+        String sql = "UPDATE " + tableName + " SET realname = ?, password = ?, ip = ?, lastlogin = ?, "
+            + "email = ?, x = ?, y = ?, z = ?, world = ?, yaw = ?, pitch = ?, "
+            + "quitx = ?, quity = ?, quitz = ?, quitworld = ?, quityaw = ?, quitpitch = ? "
+            + "WHERE username = ?";
+        
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            
+            stmt.setString(1, auth.getRealName());
+            stmt.setString(2, auth.getPassword());
+            stmt.setString(3, auth.getLastIp());
+            stmt.setLong(4, auth.getLastLogin());
+            stmt.setString(5, auth.getEmail());
+            
+            Location loc = auth.getLastLocation();
+            if (loc != null && loc.getWorld() != null) {
+                stmt.setDouble(6, loc.getX());
+                stmt.setDouble(7, loc.getY());
+                stmt.setDouble(8, loc.getZ());
+                stmt.setString(9, loc.getWorld().getName());
+                stmt.setFloat(10, loc.getYaw());
+                stmt.setFloat(11, loc.getPitch());
+            } else {
+                stmt.setDouble(6, 0);
+                stmt.setDouble(7, 0);
+                stmt.setDouble(8, 0);
+                stmt.setString(9, "world");
+                stmt.setFloat(10, 0);
+                stmt.setFloat(11, 0);
+            }
+            
+            Location quitLoc = auth.getQuitLocation();
+            if (quitLoc != null && quitLoc.getWorld() != null) {
+                stmt.setDouble(12, quitLoc.getX());
+                stmt.setDouble(13, quitLoc.getY());
+                stmt.setDouble(14, quitLoc.getZ());
+                stmt.setString(15, quitLoc.getWorld().getName());
+                stmt.setFloat(16, quitLoc.getYaw());
+                stmt.setFloat(17, quitLoc.getPitch());
+            } else {
+                stmt.setDouble(12, 0);
+                stmt.setDouble(13, 0);
+                stmt.setDouble(14, 0);
+                stmt.setString(15, "world");
+                stmt.setFloat(16, 0);
+                stmt.setFloat(17, 0);
+            }
+            
+            stmt.setString(18, auth.getUsername().toLowerCase());
+            
+            return stmt.executeUpdate() > 0;
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not update auth data for " + auth.getUsername(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean removeAuth(String username) {
+        String sql = "DELETE FROM " + tableName + " WHERE username = ?";
+        
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            
+            stmt.setString(1, username.toLowerCase());
+            
+            return stmt.executeUpdate() > 0;
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not remove auth data for " + username, e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isAuthAvailable(String username) {
+        String sql = "SELECT 1 FROM " + tableName + " WHERE username = ? LIMIT 1";
+        
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            
+            stmt.setString(1, username.toLowerCase());
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not check auth availability for " + username, e);
+            return false;
+        }
+    }
+
+    @Override
+    public List<PlayerAuth> getAllPlayers() {
+        List<PlayerAuth> players = new ArrayList<>();
+        String sql = "SELECT * FROM " + tableName;
+        
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(sql)) {
+            
+            while (rs.next()) {
+                Location loc = new Location(
+                    plugin.getServer().getWorld(rs.getString("world")),
+                    rs.getDouble("x"),
+                    rs.getDouble("y"),
+                    rs.getDouble("z"),
+                    rs.getFloat("yaw"),
+                    rs.getFloat("pitch")
+                );
+                
+                Location quitLoc = new Location(
+                    plugin.getServer().getWorld(rs.getString("quitworld")),
+                    rs.getDouble("quitx"),
+                    rs.getDouble("quity"),
+                    rs.getDouble("quitz"),
+                    rs.getFloat("quityaw"),
+                    rs.getFloat("quitpitch")
+                );
+                
+                PlayerAuth auth = new PlayerAuth(
+                    rs.getString("realname"),
+                    rs.getString("username"),
+                    rs.getString("password"),
+                    rs.getString("ip"),
+                    rs.getLong("lastlogin"),
+                    rs.getString("email"),
+                    loc
+                );
+                
+                auth.setQuitLocation(quitLoc);
+                
+                players.add(auth);
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not get all players", e);
+        }
+        
+        return players;
+    }
+
+    @Override
+    public int countAccountsForIp(String ip) {
+        String sql = "SELECT COUNT(*) FROM " + tableName + " WHERE ip = ?";
+        
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            
+            stmt.setString(1, ip);
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not count accounts for IP " + ip, e);
+        }
+        
+        return 0;
+    }
+
+    @Override
+    public List<String> getAccountsForIp(String ip) {
+        List<String> accounts = new ArrayList<>();
+        String sql = "SELECT username FROM " + tableName + " WHERE ip = ?";
+        
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            
+            stmt.setString(1, ip);
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    accounts.add(rs.getString("username"));
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not get accounts for IP " + ip, e);
+        }
+        
+        return accounts;
+    }
+
+    @Override
+    public int purgeOldData(int days) {
+        long maxAge = System.currentTimeMillis() - (days * 24L * 60L * 60L * 1000L);
+        String sql = "DELETE FROM " + tableName + " WHERE lastlogin < ?";
+        
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            
+            stmt.setLong(1, maxAge);
+            
+            return stmt.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not purge old data", e);
+            return 0;
+        }
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/SQLiteDataSource.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/SQLiteDataSource.java
@@ -1,0 +1,389 @@
+package com.simpleauth.plugin.database;
+
+import com.simpleauth.plugin.model.PlayerAuth;
+import org.bukkit.Location;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ * SQLite implementation of the AuthDataSource interface
+ */
+public class SQLiteDataSource implements AuthDataSource {
+    private final JavaPlugin plugin;
+    private final File databaseFile;
+    private final String tableName;
+    private Connection connection;
+
+    /**
+     * Constructor for SQLiteDataSource
+     * 
+     * @param plugin The plugin instance
+     * @param databaseFile The database file
+     * @param tableName The table name
+     */
+    public SQLiteDataSource(JavaPlugin plugin, File databaseFile, String tableName) {
+        this.plugin = plugin;
+        this.databaseFile = databaseFile;
+        this.tableName = tableName;
+    }
+
+    @Override
+    public void initialize() {
+        try {
+            // Ensure parent directory exists
+            if (!databaseFile.getParentFile().exists()) {
+                databaseFile.getParentFile().mkdirs();
+            }
+            
+            // Load SQLite JDBC driver
+            Class.forName("org.sqlite.JDBC");
+            
+            // Create connection
+            connection = DriverManager.getConnection("jdbc:sqlite:" + databaseFile.getAbsolutePath());
+            
+            // Create table if it doesn't exist
+            createTable();
+        } catch (ClassNotFoundException | SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not initialize SQLite connection", e);
+        }
+    }
+
+    private void createTable() {
+        String sql = "CREATE TABLE IF NOT EXISTS " + tableName + " ("
+            + "username TEXT PRIMARY KEY, "
+            + "realname TEXT NOT NULL, "
+            + "password TEXT NOT NULL, "
+            + "ip TEXT NOT NULL, "
+            + "lastlogin INTEGER NOT NULL, "
+            + "email TEXT, "
+            + "x REAL DEFAULT 0, "
+            + "y REAL DEFAULT 0, "
+            + "z REAL DEFAULT 0, "
+            + "world TEXT DEFAULT 'world', "
+            + "yaw REAL DEFAULT 0, "
+            + "pitch REAL DEFAULT 0, "
+            + "quitx REAL DEFAULT 0, "
+            + "quity REAL DEFAULT 0, "
+            + "quitz REAL DEFAULT 0, "
+            + "quitworld TEXT DEFAULT 'world', "
+            + "quityaw REAL DEFAULT 0, "
+            + "quitpitch REAL DEFAULT 0"
+            + ")";
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.executeUpdate(sql);
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not create auth table", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (connection != null && !connection.isClosed()) {
+                connection.close();
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not close SQLite connection", e);
+        }
+    }
+
+    @Override
+    public PlayerAuth getAuth(String username) {
+        String sql = "SELECT * FROM " + tableName + " WHERE username = ? LIMIT 1";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, username.toLowerCase());
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    Location loc = new Location(
+                        plugin.getServer().getWorld(rs.getString("world")),
+                        rs.getDouble("x"),
+                        rs.getDouble("y"),
+                        rs.getDouble("z"),
+                        rs.getFloat("yaw"),
+                        rs.getFloat("pitch")
+                    );
+                    
+                    Location quitLoc = new Location(
+                        plugin.getServer().getWorld(rs.getString("quitworld")),
+                        rs.getDouble("quitx"),
+                        rs.getDouble("quity"),
+                        rs.getDouble("quitz"),
+                        rs.getFloat("quityaw"),
+                        rs.getFloat("quitpitch")
+                    );
+                    
+                    PlayerAuth auth = new PlayerAuth(
+                        rs.getString("realname"),
+                        rs.getString("username"),
+                        rs.getString("password"),
+                        rs.getString("ip"),
+                        rs.getLong("lastlogin"),
+                        rs.getString("email"),
+                        loc
+                    );
+                    
+                    auth.setQuitLocation(quitLoc);
+                    
+                    return auth;
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not get auth data for " + username, e);
+        }
+        
+        return null;
+    }
+
+    @Override
+    public boolean saveAuth(PlayerAuth auth) {
+        String sql = "INSERT INTO " + tableName + " (username, realname, password, ip, lastlogin, "
+            + "email, x, y, z, world, yaw, pitch, quitx, quity, quitz, quitworld, quityaw, quitpitch) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, auth.getUsername().toLowerCase());
+            stmt.setString(2, auth.getRealName());
+            stmt.setString(3, auth.getPassword());
+            stmt.setString(4, auth.getLastIp());
+            stmt.setLong(5, auth.getLastLogin());
+            stmt.setString(6, auth.getEmail());
+            
+            Location loc = auth.getLastLocation();
+            if (loc != null && loc.getWorld() != null) {
+                stmt.setDouble(7, loc.getX());
+                stmt.setDouble(8, loc.getY());
+                stmt.setDouble(9, loc.getZ());
+                stmt.setString(10, loc.getWorld().getName());
+                stmt.setFloat(11, loc.getYaw());
+                stmt.setFloat(12, loc.getPitch());
+            } else {
+                stmt.setDouble(7, 0);
+                stmt.setDouble(8, 0);
+                stmt.setDouble(9, 0);
+                stmt.setString(10, "world");
+                stmt.setFloat(11, 0);
+                stmt.setFloat(12, 0);
+            }
+            
+            Location quitLoc = auth.getQuitLocation();
+            if (quitLoc != null && quitLoc.getWorld() != null) {
+                stmt.setDouble(13, quitLoc.getX());
+                stmt.setDouble(14, quitLoc.getY());
+                stmt.setDouble(15, quitLoc.getZ());
+                stmt.setString(16, quitLoc.getWorld().getName());
+                stmt.setFloat(17, quitLoc.getYaw());
+                stmt.setFloat(18, quitLoc.getPitch());
+            } else {
+                stmt.setDouble(13, 0);
+                stmt.setDouble(14, 0);
+                stmt.setDouble(15, 0);
+                stmt.setString(16, "world");
+                stmt.setFloat(17, 0);
+                stmt.setFloat(18, 0);
+            }
+            
+            return stmt.executeUpdate() > 0;
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not save auth data for " + auth.getUsername(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean updateAuth(PlayerAuth auth) {
+        String sql = "UPDATE " + tableName + " SET realname = ?, password = ?, ip = ?, lastlogin = ?, "
+            + "email = ?, x = ?, y = ?, z = ?, world = ?, yaw = ?, pitch = ?, "
+            + "quitx = ?, quity = ?, quitz = ?, quitworld = ?, quityaw = ?, quitpitch = ? "
+            + "WHERE username = ?";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, auth.getRealName());
+            stmt.setString(2, auth.getPassword());
+            stmt.setString(3, auth.getLastIp());
+            stmt.setLong(4, auth.getLastLogin());
+            stmt.setString(5, auth.getEmail());
+            
+            Location loc = auth.getLastLocation();
+            if (loc != null && loc.getWorld() != null) {
+                stmt.setDouble(6, loc.getX());
+                stmt.setDouble(7, loc.getY());
+                stmt.setDouble(8, loc.getZ());
+                stmt.setString(9, loc.getWorld().getName());
+                stmt.setFloat(10, loc.getYaw());
+                stmt.setFloat(11, loc.getPitch());
+            } else {
+                stmt.setDouble(6, 0);
+                stmt.setDouble(7, 0);
+                stmt.setDouble(8, 0);
+                stmt.setString(9, "world");
+                stmt.setFloat(10, 0);
+                stmt.setFloat(11, 0);
+            }
+            
+            Location quitLoc = auth.getQuitLocation();
+            if (quitLoc != null && quitLoc.getWorld() != null) {
+                stmt.setDouble(12, quitLoc.getX());
+                stmt.setDouble(13, quitLoc.getY());
+                stmt.setDouble(14, quitLoc.getZ());
+                stmt.setString(15, quitLoc.getWorld().getName());
+                stmt.setFloat(16, quitLoc.getYaw());
+                stmt.setFloat(17, quitLoc.getPitch());
+            } else {
+                stmt.setDouble(12, 0);
+                stmt.setDouble(13, 0);
+                stmt.setDouble(14, 0);
+                stmt.setString(15, "world");
+                stmt.setFloat(16, 0);
+                stmt.setFloat(17, 0);
+            }
+            
+            stmt.setString(18, auth.getUsername().toLowerCase());
+            
+            return stmt.executeUpdate() > 0;
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not update auth data for " + auth.getUsername(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean removeAuth(String username) {
+        String sql = "DELETE FROM " + tableName + " WHERE username = ?";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, username.toLowerCase());
+            
+            return stmt.executeUpdate() > 0;
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not remove auth data for " + username, e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isAuthAvailable(String username) {
+        String sql = "SELECT 1 FROM " + tableName + " WHERE username = ? LIMIT 1";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, username.toLowerCase());
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not check auth availability for " + username, e);
+            return false;
+        }
+    }
+
+    @Override
+    public List<PlayerAuth> getAllPlayers() {
+        List<PlayerAuth> players = new ArrayList<>();
+        String sql = "SELECT * FROM " + tableName;
+        
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery(sql)) {
+            
+            while (rs.next()) {
+                Location loc = new Location(
+                    plugin.getServer().getWorld(rs.getString("world")),
+                    rs.getDouble("x"),
+                    rs.getDouble("y"),
+                    rs.getDouble("z"),
+                    rs.getFloat("yaw"),
+                    rs.getFloat("pitch")
+                );
+                
+                Location quitLoc = new Location(
+                    plugin.getServer().getWorld(rs.getString("quitworld")),
+                    rs.getDouble("quitx"),
+                    rs.getDouble("quity"),
+                    rs.getDouble("quitz"),
+                    rs.getFloat("quityaw"),
+                    rs.getFloat("quitpitch")
+                );
+                
+                PlayerAuth auth = new PlayerAuth(
+                    rs.getString("realname"),
+                    rs.getString("username"),
+                    rs.getString("password"),
+                    rs.getString("ip"),
+                    rs.getLong("lastlogin"),
+                    rs.getString("email"),
+                    loc
+                );
+                
+                auth.setQuitLocation(quitLoc);
+                
+                players.add(auth);
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not get all players", e);
+        }
+        
+        return players;
+    }
+
+    @Override
+    public int countAccountsForIp(String ip) {
+        String sql = "SELECT COUNT(*) FROM " + tableName + " WHERE ip = ?";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, ip);
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not count accounts for IP " + ip, e);
+        }
+        
+        return 0;
+    }
+
+    @Override
+    public List<String> getAccountsForIp(String ip) {
+        List<String> accounts = new ArrayList<>();
+        String sql = "SELECT username FROM " + tableName + " WHERE ip = ?";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, ip);
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    accounts.add(rs.getString("username"));
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not get accounts for IP " + ip, e);
+        }
+        
+        return accounts;
+    }
+
+    @Override
+    public int purgeOldData(int days) {
+        long maxAge = System.currentTimeMillis() - (days * 24L * 60L * 60L * 1000L);
+        String sql = "DELETE FROM " + tableName + " WHERE lastlogin < ?";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setLong(1, maxAge);
+            
+            return stmt.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not purge old data", e);
+            return 0;
+        }
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/YamlDataSource.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/database/YamlDataSource.java
@@ -1,0 +1,273 @@
+package com.simpleauth.plugin.database;
+
+import com.simpleauth.plugin.model.PlayerAuth;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+/**
+ * YAML implementation of the AuthDataSource interface
+ */
+public class YamlDataSource implements AuthDataSource {
+    private final JavaPlugin plugin;
+    private final File dataFile;
+    private YamlConfiguration data;
+
+    /**
+     * Constructor for YamlDataSource
+     * 
+     * @param plugin The plugin instance
+     * @param dataFile The data file
+     */
+    public YamlDataSource(JavaPlugin plugin, File dataFile) {
+        this.plugin = plugin;
+        this.dataFile = dataFile;
+    }
+
+    @Override
+    public void initialize() {
+        try {
+            // Ensure parent directory exists
+            if (!dataFile.getParentFile().exists()) {
+                dataFile.getParentFile().mkdirs();
+            }
+            
+            // Create file if it doesn't exist
+            if (!dataFile.exists()) {
+                dataFile.createNewFile();
+            }
+            
+            // Load data
+            data = YamlConfiguration.loadConfiguration(dataFile);
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not initialize YAML data source", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        // Save data
+        try {
+            data.save(dataFile);
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not save YAML data", e);
+        }
+    }
+
+    @Override
+    public PlayerAuth getAuth(String username) {
+        String lowercaseUsername = username.toLowerCase();
+        
+        if (!data.contains(lowercaseUsername)) {
+            return null;
+        }
+        
+        ConfigurationSection section = data.getConfigurationSection(lowercaseUsername);
+        
+        if (section == null) {
+            return null;
+        }
+        
+        String realName = section.getString("realname");
+        String password = section.getString("password");
+        String ip = section.getString("ip");
+        long lastLogin = section.getLong("lastlogin");
+        String email = section.getString("email");
+        
+        // Get last location
+        Location lastLocation = null;
+        if (section.contains("location")) {
+            ConfigurationSection locationSection = section.getConfigurationSection("location");
+            if (locationSection != null) {
+                String world = locationSection.getString("world", "world");
+                double x = locationSection.getDouble("x", 0);
+                double y = locationSection.getDouble("y", 0);
+                double z = locationSection.getDouble("z", 0);
+                float yaw = (float) locationSection.getDouble("yaw", 0);
+                float pitch = (float) locationSection.getDouble("pitch", 0);
+                
+                lastLocation = new Location(plugin.getServer().getWorld(world), x, y, z, yaw, pitch);
+            }
+        }
+        
+        // Get quit location
+        Location quitLocation = null;
+        if (section.contains("quitlocation")) {
+            ConfigurationSection quitLocationSection = section.getConfigurationSection("quitlocation");
+            if (quitLocationSection != null) {
+                String world = quitLocationSection.getString("world", "world");
+                double x = quitLocationSection.getDouble("x", 0);
+                double y = quitLocationSection.getDouble("y", 0);
+                double z = quitLocationSection.getDouble("z", 0);
+                float yaw = (float) quitLocationSection.getDouble("yaw", 0);
+                float pitch = (float) quitLocationSection.getDouble("pitch", 0);
+                
+                quitLocation = new Location(plugin.getServer().getWorld(world), x, y, z, yaw, pitch);
+            }
+        }
+        
+        // Create PlayerAuth object
+        PlayerAuth auth = new PlayerAuth(
+            realName,
+            lowercaseUsername,
+            password,
+            ip,
+            lastLogin,
+            email,
+            lastLocation != null ? lastLocation : new Location(plugin.getServer().getWorld("world"), 0, 0, 0)
+        );
+        
+        if (quitLocation != null) {
+            auth.setQuitLocation(quitLocation);
+        }
+        
+        return auth;
+    }
+
+    @Override
+    public boolean saveAuth(PlayerAuth auth) {
+        String lowercaseUsername = auth.getUsername().toLowerCase();
+        
+        ConfigurationSection section = data.createSection(lowercaseUsername);
+        
+        section.set("realname", auth.getRealName());
+        section.set("password", auth.getPassword());
+        section.set("ip", auth.getLastIp());
+        section.set("lastlogin", auth.getLastLogin());
+        section.set("email", auth.getEmail());
+        
+        // Save last location
+        Location lastLocation = auth.getLastLocation();
+        if (lastLocation != null && lastLocation.getWorld() != null) {
+            ConfigurationSection locationSection = section.createSection("location");
+            locationSection.set("world", lastLocation.getWorld().getName());
+            locationSection.set("x", lastLocation.getX());
+            locationSection.set("y", lastLocation.getY());
+            locationSection.set("z", lastLocation.getZ());
+            locationSection.set("yaw", lastLocation.getYaw());
+            locationSection.set("pitch", lastLocation.getPitch());
+        }
+        
+        // Save quit location
+        Location quitLocation = auth.getQuitLocation();
+        if (quitLocation != null && quitLocation.getWorld() != null) {
+            ConfigurationSection quitLocationSection = section.createSection("quitlocation");
+            quitLocationSection.set("world", quitLocation.getWorld().getName());
+            quitLocationSection.set("x", quitLocation.getX());
+            quitLocationSection.set("y", quitLocation.getY());
+            quitLocationSection.set("z", quitLocation.getZ());
+            quitLocationSection.set("yaw", quitLocation.getYaw());
+            quitLocationSection.set("pitch", quitLocation.getPitch());
+        }
+        
+        try {
+            data.save(dataFile);
+            return true;
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not save auth data for " + auth.getUsername(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean updateAuth(PlayerAuth auth) {
+        // For YAML, save and update are the same
+        return saveAuth(auth);
+    }
+
+    @Override
+    public boolean removeAuth(String username) {
+        String lowercaseUsername = username.toLowerCase();
+        
+        if (!data.contains(lowercaseUsername)) {
+            return false;
+        }
+        
+        data.set(lowercaseUsername, null);
+        
+        try {
+            data.save(dataFile);
+            return true;
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not remove auth data for " + username, e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isAuthAvailable(String username) {
+        return data.contains(username.toLowerCase());
+    }
+
+    @Override
+    public List<PlayerAuth> getAllPlayers() {
+        List<PlayerAuth> players = new ArrayList<>();
+        
+        for (String key : data.getKeys(false)) {
+            PlayerAuth auth = getAuth(key);
+            if (auth != null) {
+                players.add(auth);
+            }
+        }
+        
+        return players;
+    }
+
+    @Override
+    public int countAccountsForIp(String ip) {
+        int count = 0;
+        
+        for (String key : data.getKeys(false)) {
+            ConfigurationSection section = data.getConfigurationSection(key);
+            if (section != null && ip.equals(section.getString("ip"))) {
+                count++;
+            }
+        }
+        
+        return count;
+    }
+
+    @Override
+    public List<String> getAccountsForIp(String ip) {
+        List<String> accounts = new ArrayList<>();
+        
+        for (String key : data.getKeys(false)) {
+            ConfigurationSection section = data.getConfigurationSection(key);
+            if (section != null && ip.equals(section.getString("ip"))) {
+                accounts.add(key);
+            }
+        }
+        
+        return accounts;
+    }
+
+    @Override
+    public int purgeOldData(int days) {
+        long maxAge = System.currentTimeMillis() - (days * 24L * 60L * 60L * 1000L);
+        int count = 0;
+        
+        for (String key : new ArrayList<>(data.getKeys(false))) {
+            ConfigurationSection section = data.getConfigurationSection(key);
+            if (section != null && section.getLong("lastlogin", 0) < maxAge) {
+                data.set(key, null);
+                count++;
+            }
+        }
+        
+        try {
+            data.save(dataFile);
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not save data after purging", e);
+        }
+        
+        return count;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/events/PlayerLoginEvent.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/events/PlayerLoginEvent.java
@@ -1,0 +1,46 @@
+package com.simpleauth.plugin.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event fired when a player logs in
+ */
+public class PlayerLoginEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private final Player player;
+
+    /**
+     * Constructor for PlayerLoginEvent
+     * 
+     * @param player The player
+     */
+    public PlayerLoginEvent(Player player) {
+        this.player = player;
+    }
+
+    /**
+     * Get the player
+     * 
+     * @return The player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    /**
+     * Get the handler list
+     * 
+     * @return The handler list
+     */
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/events/PlayerLogoutEvent.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/events/PlayerLogoutEvent.java
@@ -1,0 +1,46 @@
+package com.simpleauth.plugin.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event fired when a player logs out
+ */
+public class PlayerLogoutEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private final Player player;
+
+    /**
+     * Constructor for PlayerLogoutEvent
+     * 
+     * @param player The player
+     */
+    public PlayerLogoutEvent(Player player) {
+        this.player = player;
+    }
+
+    /**
+     * Get the player
+     * 
+     * @return The player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    /**
+     * Get the handler list
+     * 
+     * @return The handler list
+     */
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/events/PlayerRegisterEvent.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/events/PlayerRegisterEvent.java
@@ -1,0 +1,46 @@
+package com.simpleauth.plugin.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event fired when a player registers
+ */
+public class PlayerRegisterEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private final Player player;
+
+    /**
+     * Constructor for PlayerRegisterEvent
+     * 
+     * @param player The player
+     */
+    public PlayerRegisterEvent(Player player) {
+        this.player = player;
+    }
+
+    /**
+     * Get the player
+     * 
+     * @return The player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    /**
+     * Get the handler list
+     * 
+     * @return The handler list
+     */
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/events/PlayerUnregisterEvent.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/events/PlayerUnregisterEvent.java
@@ -1,0 +1,46 @@
+package com.simpleauth.plugin.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event fired when a player unregisters
+ */
+public class PlayerUnregisterEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private final Player player;
+
+    /**
+     * Constructor for PlayerUnregisterEvent
+     * 
+     * @param player The player
+     */
+    public PlayerUnregisterEvent(Player player) {
+        this.player = player;
+    }
+
+    /**
+     * Get the player
+     * 
+     * @return The player
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    /**
+     * Get the handler list
+     * 
+     * @return The handler list
+     */
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/listeners/PlayerAuthListener.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/listeners/PlayerAuthListener.java
@@ -1,0 +1,95 @@
+package com.simpleauth.plugin.listeners;
+
+import com.simpleauth.plugin.AuthManager;
+import com.simpleauth.plugin.util.MessageUtil;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+/**
+ * Listener for player authentication events
+ */
+public class PlayerAuthListener implements Listener {
+    private final JavaPlugin plugin;
+    private final AuthManager authManager;
+
+    /**
+     * Constructor for PlayerAuthListener
+     * 
+     * @param plugin The plugin instance
+     * @param authManager The auth manager
+     */
+    public PlayerAuthListener(JavaPlugin plugin, AuthManager authManager) {
+        this.plugin = plugin;
+        this.authManager = authManager;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is premium and premium auto-login is enabled
+        if (plugin.getConfig().getBoolean("premium.enabled", true) && authManager.isPremium(player.getUniqueId())) {
+            // Auto-login premium player
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    if (player.isOnline() && !authManager.isAuthenticated(player.getName())) {
+                        authManager.login(player);
+                        MessageUtil.sendMessage(player, "loginSuccess");
+                    }
+                }
+            }.runTaskLater(plugin, 1L);
+            return;
+        }
+        
+        // Check if player has a valid session
+        if (plugin.getConfig().getBoolean("session.enabled", true) && 
+            authManager.isRegistered(player.getName()) && 
+            authManager.getSessionManager().hasValidSession(player)) {
+            
+            // Auto-login player with valid session
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    if (player.isOnline() && !authManager.isAuthenticated(player.getName())) {
+                        authManager.login(player);
+                        MessageUtil.sendMessage(player, "loginSuccess");
+                    }
+                }
+            }.runTaskLater(plugin, 1L);
+            return;
+        }
+        
+        // Apply restrictions for unauthenticated player
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (player.isOnline() && !authManager.isAuthenticated(player.getName())) {
+                    authManager.applyRestrictions(player);
+                }
+            }
+        }.runTaskLater(plugin, 1L);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        
+        // Update quit location if player is authenticated
+        if (authManager.isAuthenticated(player.getName())) {
+            // Get player auth data
+            String username = player.getName().toLowerCase();
+            
+            // Update quit location in database
+            authManager.getDataSource().getAuth(username).setQuitLocation(player.getLocation());
+            authManager.getDataSource().updateAuth(authManager.getDataSource().getAuth(username));
+        }
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/listeners/PlayerProtectionListener.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/listeners/PlayerProtectionListener.java
@@ -1,0 +1,168 @@
+package com.simpleauth.plugin.listeners;
+
+import com.simpleauth.plugin.AuthManager;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.player.*;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.List;
+
+/**
+ * Listener for player protection events
+ */
+public class PlayerProtectionListener implements Listener {
+    private final JavaPlugin plugin;
+    private final AuthManager authManager;
+
+    /**
+     * Constructor for PlayerProtectionListener
+     * 
+     * @param plugin The plugin instance
+     * @param authManager The auth manager
+     */
+    public PlayerProtectionListener(JavaPlugin plugin, AuthManager authManager) {
+        this.plugin = plugin;
+        this.authManager = authManager;
+    }
+
+    /**
+     * Check if a player is protected
+     * 
+     * @param player The player
+     * @return True if the player is protected, false otherwise
+     */
+    private boolean isProtected(Player player) {
+        return player != null && !authManager.isAuthenticated(player.getName());
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerMove(PlayerMoveEvent event) {
+        if (isProtected(event.getPlayer()) && !plugin.getConfig().getBoolean("restrictions.allowMovement", false)) {
+            // Cancel movement if not allowed
+            if (event.getFrom().getBlockX() != event.getTo().getBlockX() || 
+                event.getFrom().getBlockZ() != event.getTo().getBlockZ()) {
+                event.setTo(event.getFrom());
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerChat(AsyncPlayerChatEvent event) {
+        if (isProtected(event.getPlayer()) && !plugin.getConfig().getBoolean("restrictions.allowChat", false)) {
+            // Cancel chat if not allowed
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerCommand(PlayerCommandPreprocessEvent event) {
+        if (isProtected(event.getPlayer())) {
+            // Get allowed commands
+            List<String> allowedCommands = plugin.getConfig().getStringList("restrictions.allowedCommands");
+            
+            // Check if command is allowed
+            String command = event.getMessage().split(" ")[0].toLowerCase();
+            if (!allowedCommands.contains(command)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockBreak(BlockBreakEvent event) {
+        if (isProtected(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if (isProtected(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        if (isProtected(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        if (isProtected(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerDropItem(PlayerDropItemEvent event) {
+        if (isProtected(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerPickupItem(EntityPickupItemEvent event) {
+        if (event.getEntity() instanceof Player player && isProtected(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        if (event.getPlayer() instanceof Player player && isProtected(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.getWhoClicked() instanceof Player player && isProtected(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onEntityDamage(EntityDamageEvent event) {
+        if (event.getEntity() instanceof Player player && isProtected(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onEntityTarget(EntityTargetEvent event) {
+        if (event.getTarget() instanceof Player player && isProtected(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onFoodLevelChange(FoodLevelChangeEvent event) {
+        if (event.getEntity() instanceof Player player && isProtected(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerGameModeChange(PlayerGameModeChangeEvent event) {
+        if (isProtected(event.getPlayer()) && plugin.getConfig().getBoolean("restrictions.forceSurvivalMode", true)) {
+            event.setCancelled(true);
+            event.getPlayer().setGameMode(GameMode.SURVIVAL);
+        }
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/listeners/PlayerProtectionListener.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/listeners/PlayerProtectionListener.java
@@ -59,7 +59,7 @@ public class PlayerProtectionListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    public void onPlayerChat(AsyncPlayerChatEvent event) {
+    public void onPlayerChat(PlayerChatEvent event) {
         if (isProtected(event.getPlayer()) && !plugin.getConfig().getBoolean("restrictions.allowChat", false)) {
             // Cancel chat if not allowed
             event.setCancelled(true);
@@ -165,4 +165,3 @@ public class PlayerProtectionListener implements Listener {
         }
     }
 }
-

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/model/PlayerAuth.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/model/PlayerAuth.java
@@ -1,0 +1,166 @@
+package com.simpleauth.plugin.model;
+
+import org.bukkit.Location;
+
+/**
+ * Represents a player's authentication data
+ */
+public class PlayerAuth {
+    private final String username;
+    private final String realName;
+    private String password;
+    private String lastIp;
+    private long lastLogin;
+    private String email;
+    private Location lastLocation;
+    private Location quitLocation;
+
+    /**
+     * Constructor for PlayerAuth
+     * 
+     * @param realName The player's real name (case-sensitive)
+     * @param username The player's username (lowercase)
+     * @param password The player's password (plain text)
+     * @param ip The player's IP address
+     * @param lastLogin The player's last login time
+     * @param email The player's email (optional)
+     * @param lastLocation The player's last location
+     */
+    public PlayerAuth(String realName, String username, String password, String ip, long lastLogin, String email, Location lastLocation) {
+        this.realName = realName;
+        this.username = username;
+        this.password = password;
+        this.lastIp = ip;
+        this.lastLogin = lastLogin;
+        this.email = email;
+        this.lastLocation = lastLocation;
+        this.quitLocation = lastLocation;
+    }
+
+    /**
+     * Get the player's username (lowercase)
+     * 
+     * @return The player's username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Get the player's real name (case-sensitive)
+     * 
+     * @return The player's real name
+     */
+    public String getRealName() {
+        return realName;
+    }
+
+    /**
+     * Get the player's password (plain text)
+     * 
+     * @return The player's password
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Set the player's password (plain text)
+     * 
+     * @param password The new password
+     */
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    /**
+     * Get the player's last IP address
+     * 
+     * @return The player's last IP address
+     */
+    public String getLastIp() {
+        return lastIp;
+    }
+
+    /**
+     * Set the player's last IP address
+     * 
+     * @param lastIp The new last IP address
+     */
+    public void setLastIp(String lastIp) {
+        this.lastIp = lastIp;
+    }
+
+    /**
+     * Get the player's last login time
+     * 
+     * @return The player's last login time
+     */
+    public long getLastLogin() {
+        return lastLogin;
+    }
+
+    /**
+     * Set the player's last login time
+     * 
+     * @param lastLogin The new last login time
+     */
+    public void setLastLogin(long lastLogin) {
+        this.lastLogin = lastLogin;
+    }
+
+    /**
+     * Get the player's email
+     * 
+     * @return The player's email
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    /**
+     * Set the player's email
+     * 
+     * @param email The new email
+     */
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    /**
+     * Get the player's last location
+     * 
+     * @return The player's last location
+     */
+    public Location getLastLocation() {
+        return lastLocation;
+    }
+
+    /**
+     * Set the player's last location
+     * 
+     * @param lastLocation The new last location
+     */
+    public void setLastLocation(Location lastLocation) {
+        this.lastLocation = lastLocation;
+    }
+
+    /**
+     * Get the player's quit location
+     * 
+     * @return The player's quit location
+     */
+    public Location getQuitLocation() {
+        return quitLocation;
+    }
+
+    /**
+     * Set the player's quit location
+     * 
+     * @param quitLocation The new quit location
+     */
+    public void setQuitLocation(Location quitLocation) {
+        this.quitLocation = quitLocation;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/session/PlayerSession.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/session/PlayerSession.java
@@ -1,0 +1,53 @@
+package com.simpleauth.plugin.session;
+
+import java.util.UUID;
+
+/**
+ * Represents a player session
+ */
+public class PlayerSession {
+    private final UUID playerUuid;
+    private final String ip;
+    private final long creationTime;
+
+    /**
+     * Constructor for PlayerSession
+     * 
+     * @param playerUuid The player's UUID
+     * @param ip The player's IP address
+     * @param creationTime The session creation time
+     */
+    public PlayerSession(UUID playerUuid, String ip, long creationTime) {
+        this.playerUuid = playerUuid;
+        this.ip = ip;
+        this.creationTime = creationTime;
+    }
+
+    /**
+     * Get the player's UUID
+     * 
+     * @return The player's UUID
+     */
+    public UUID getPlayerUuid() {
+        return playerUuid;
+    }
+
+    /**
+     * Get the player's IP address
+     * 
+     * @return The player's IP address
+     */
+    public String getIp() {
+        return ip;
+    }
+
+    /**
+     * Get the session creation time
+     * 
+     * @return The session creation time
+     */
+    public long getCreationTime() {
+        return creationTime;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/session/SessionManager.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/session/SessionManager.java
@@ -1,0 +1,124 @@
+package com.simpleauth.plugin.session;
+
+import com.simpleauth.plugin.database.AuthDataSource;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Manages player sessions
+ */
+public class SessionManager {
+    private final JavaPlugin plugin;
+    private final AuthDataSource dataSource;
+    private final Map<UUID, PlayerSession> sessions;
+    
+    private boolean enabled;
+    private long timeout;
+    private boolean validateIp;
+
+    /**
+     * Constructor for SessionManager
+     * 
+     * @param plugin The plugin instance
+     * @param dataSource The data source
+     */
+    public SessionManager(JavaPlugin plugin, AuthDataSource dataSource) {
+        this.plugin = plugin;
+        this.dataSource = dataSource;
+        this.sessions = new HashMap<>();
+        
+        // Load settings
+        reload();
+    }
+
+    /**
+     * Reload the session manager
+     */
+    public void reload() {
+        enabled = plugin.getConfig().getBoolean("session.enabled", true);
+        timeout = plugin.getConfig().getLong("session.timeout", 60) * 60 * 1000; // Convert minutes to milliseconds
+        validateIp = plugin.getConfig().getBoolean("session.validateIp", true);
+    }
+
+    /**
+     * Create a session for a player
+     * 
+     * @param player The player
+     */
+    public void createSession(Player player) {
+        if (!enabled) {
+            return;
+        }
+        
+        UUID uuid = player.getUniqueId();
+        String ip = player.getAddress().getAddress().getHostAddress();
+        
+        PlayerSession session = new PlayerSession(uuid, ip, System.currentTimeMillis());
+        sessions.put(uuid, session);
+    }
+
+    /**
+     * Check if a player has a valid session
+     * 
+     * @param player The player
+     * @return True if the player has a valid session, false otherwise
+     */
+    public boolean hasValidSession(Player player) {
+        if (!enabled) {
+            return false;
+        }
+        
+        UUID uuid = player.getUniqueId();
+        String ip = player.getAddress().getAddress().getHostAddress();
+        
+        PlayerSession session = sessions.get(uuid);
+        
+        if (session == null) {
+            return false;
+        }
+        
+        // Check if session has expired
+        if (System.currentTimeMillis() - session.getCreationTime() > timeout) {
+            sessions.remove(uuid);
+            return false;
+        }
+        
+        // Check if IP matches
+        if (validateIp && !session.getIp().equals(ip)) {
+            sessions.remove(uuid);
+            return false;
+        }
+        
+        return true;
+    }
+
+    /**
+     * Remove a player's session
+     * 
+     * @param player The player
+     */
+    public void removeSession(Player player) {
+        sessions.remove(player.getUniqueId());
+    }
+
+    /**
+     * Clear all sessions
+     */
+    public void clearSessions() {
+        sessions.clear();
+    }
+
+    /**
+     * Get the number of active sessions
+     * 
+     * @return The number of active sessions
+     */
+    public int getSessionCount() {
+        return sessions.size();
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/util/LocationUtil.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/util/LocationUtil.java
@@ -1,0 +1,98 @@
+package com.simpleauth.plugin.util;
+
+import org.bukkit.Location;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.logging.Level;
+
+/**
+ * Utility class for locations
+ */
+public class LocationUtil {
+    private static final String LOCATIONS_FILE = "locations.yml";
+
+    /**
+     * Store a player's location
+     * 
+     * @param plugin The plugin instance
+     * @param uuid The player's UUID
+     * @param location The location to store
+     */
+    public static void storeLocation(JavaPlugin plugin, UUID uuid, Location location) {
+        File file = new File(plugin.getDataFolder(), LOCATIONS_FILE);
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        
+        String path = uuid.toString();
+        config.set(path + ".world", location.getWorld().getName());
+        config.set(path + ".x", location.getX());
+        config.set(path + ".y", location.getY());
+        config.set(path + ".z", location.getZ());
+        config.set(path + ".yaw", location.getYaw());
+        config.set(path + ".pitch", location.getPitch());
+        
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not save location for " + uuid, e);
+        }
+    }
+
+    /**
+     * Get a player's stored location
+     * 
+     * @param plugin The plugin instance
+     * @param uuid The player's UUID
+     * @return The stored location, or null if not found
+     */
+    public static Location getStoredLocation(JavaPlugin plugin, UUID uuid) {
+        File file = new File(plugin.getDataFolder(), LOCATIONS_FILE);
+        if (!file.exists()) {
+            return null;
+        }
+        
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        
+        String path = uuid.toString();
+        if (!config.contains(path)) {
+            return null;
+        }
+        
+        String worldName = config.getString(path + ".world");
+        double x = config.getDouble(path + ".x");
+        double y = config.getDouble(path + ".y");
+        double z = config.getDouble(path + ".z");
+        float yaw = (float) config.getDouble(path + ".yaw");
+        float pitch = (float) config.getDouble(path + ".pitch");
+        
+        return new Location(plugin.getServer().getWorld(worldName), x, y, z, yaw, pitch);
+    }
+
+    /**
+     * Remove a player's stored location
+     * 
+     * @param plugin The plugin instance
+     * @param uuid The player's UUID
+     */
+    public static void removeStoredLocation(JavaPlugin plugin, UUID uuid) {
+        File file = new File(plugin.getDataFolder(), LOCATIONS_FILE);
+        if (!file.exists()) {
+            return;
+        }
+        
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        
+        String path = uuid.toString();
+        config.set(path, null);
+        
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().log(Level.SEVERE, "Could not remove location for " + uuid, e);
+        }
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/util/MessageUtil.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/util/MessageUtil.java
@@ -1,6 +1,9 @@
 package com.simpleauth.plugin.util;
 
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -10,6 +13,11 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class MessageUtil {
     private static JavaPlugin plugin;
     private static String prefix;
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.builder()
+            .character('&')
+            .hexColors()
+            .build();
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
 
     /**
      * Initialize the message utility
@@ -18,7 +26,7 @@ public class MessageUtil {
      */
     public static void init(JavaPlugin plugin) {
         MessageUtil.plugin = plugin;
-        prefix = ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("messages.prefix", "&8[&6SimpleAuth&8] &r"));
+        prefix = formatMessage(plugin.getConfig().getString("messages.prefix", "&8[&6SimpleAuth&8] &r"));
     }
 
     /**
@@ -28,7 +36,8 @@ public class MessageUtil {
      * @param message The message
      */
     public static void sendMessage(Player player, String message) {
-        player.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("messages." + message, message)));
+        String configMessage = plugin.getConfig().getString("messages." + message, message);
+        player.sendMessage(Component.text(prefix).append(LEGACY_SERIALIZER.deserialize(configMessage)));
     }
 
     /**
@@ -38,7 +47,7 @@ public class MessageUtil {
      * @param message The message
      */
     public static void sendRawMessage(Player player, String message) {
-        player.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', message));
+        player.sendMessage(Component.text(prefix).append(LEGACY_SERIALIZER.deserialize(message)));
     }
 
     /**
@@ -48,7 +57,11 @@ public class MessageUtil {
      * @return The formatted message
      */
     public static String formatMessage(String message) {
-        return ChatColor.translateAlternateColorCodes('&', message);
+        if (message == null) {
+            return "";
+        }
+        // Convert legacy color codes to plain text with colors
+        return LEGACY_SERIALIZER.serialize(LEGACY_SERIALIZER.deserialize(message));
     }
 
     /**
@@ -58,7 +71,8 @@ public class MessageUtil {
      * @return The message
      */
     public static String getMessage(String key) {
-        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("messages." + key, key));
+        String configMessage = plugin.getConfig().getString("messages." + key, key);
+        return formatMessage(configMessage);
     }
 
     /**

--- a/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/util/MessageUtil.java
+++ b/SimpleAuthPlugin/src/main/java/com/simpleauth/plugin/util/MessageUtil.java
@@ -1,0 +1,73 @@
+package com.simpleauth.plugin.util;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Utility class for messages
+ */
+public class MessageUtil {
+    private static JavaPlugin plugin;
+    private static String prefix;
+
+    /**
+     * Initialize the message utility
+     * 
+     * @param plugin The plugin instance
+     */
+    public static void init(JavaPlugin plugin) {
+        MessageUtil.plugin = plugin;
+        prefix = ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("messages.prefix", "&8[&6SimpleAuth&8] &r"));
+    }
+
+    /**
+     * Send a message to a player
+     * 
+     * @param player The player
+     * @param message The message
+     */
+    public static void sendMessage(Player player, String message) {
+        player.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("messages." + message, message)));
+    }
+
+    /**
+     * Send a raw message to a player
+     * 
+     * @param player The player
+     * @param message The message
+     */
+    public static void sendRawMessage(Player player, String message) {
+        player.sendMessage(prefix + ChatColor.translateAlternateColorCodes('&', message));
+    }
+
+    /**
+     * Format a message with color codes
+     * 
+     * @param message The message
+     * @return The formatted message
+     */
+    public static String formatMessage(String message) {
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+
+    /**
+     * Get a message from the config
+     * 
+     * @param key The message key
+     * @return The message
+     */
+    public static String getMessage(String key) {
+        return ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("messages." + key, key));
+    }
+
+    /**
+     * Get the message prefix
+     * 
+     * @return The message prefix
+     */
+    public static String getPrefix() {
+        return prefix;
+    }
+}
+

--- a/SimpleAuthPlugin/src/main/resources/config.yml
+++ b/SimpleAuthPlugin/src/main/resources/config.yml
@@ -1,0 +1,138 @@
+# SimpleAuthPlugin Configuration
+
+# Database Settings
+database:
+  # Database type: MYSQL, SQLITE, YAML
+  type: SQLITE
+  # MySQL settings (only used if type is MYSQL)
+  mysql:
+    host: localhost
+    port: 3306
+    database: simpleauth
+    username: root
+    password: password
+    # Connection pool settings
+    pool:
+      maxPoolSize: 10
+      minIdle: 5
+      maxLifetime: 1800000
+      connectionTimeout: 5000
+  # SQLite settings (only used if type is SQLITE)
+  sqlite:
+    filename: simpleauth.db
+  # Table name for auth data
+  tableName: simpleauth
+
+# Registration Settings
+registration:
+  # Whether registration is enabled
+  enabled: true
+  # Whether registration is forced (players must register)
+  forced: true
+  # Maximum number of accounts per IP address (0 = unlimited)
+  maxAccountsPerIp: 3
+  # Minimum length of password
+  minPasswordLength: 4
+  # Maximum length of password
+  maxPasswordLength: 30
+  # Whether to require an email for registration
+  requireEmail: false
+  # Whether to verify email addresses
+  verifyEmail: false
+
+# Login Settings
+login:
+  # Maximum number of login attempts before timeout
+  maxLoginAttempts: 5
+  # Timeout in seconds after max login attempts
+  loginTimeout: 300
+  # Whether to kick players on wrong password
+  kickOnWrongPassword: true
+  # Message to send on wrong password
+  wrongPasswordMessage: "Wrong password!"
+
+# Session Settings
+session:
+  # Whether to enable sessions
+  enabled: true
+  # Session timeout in minutes
+  timeout: 60
+  # Whether to validate IP for sessions
+  validateIp: true
+
+# Spawn Settings
+spawn:
+  # Whether to teleport unauthenticated players to spawn
+  teleportToSpawn: true
+  # Whether to teleport players back to their original location after login
+  teleportBackAfterLogin: true
+  # Whether to set a first spawn for new players
+  useFirstSpawn: false
+  # First spawn coordinates (only used if useFirstSpawn is true)
+  firstSpawn:
+    world: world
+    x: 0
+    y: 64
+    z: 0
+    yaw: 0
+    pitch: 0
+
+# Restriction Settings
+restrictions:
+  # Whether to allow chat for unauthenticated players
+  allowChat: false
+  # Whether to hide chat for unauthenticated players
+  hideChat: true
+  # Whether to allow movement for unauthenticated players
+  allowMovement: false
+  # Allowed movement radius if movement is allowed
+  allowedMovementRadius: 100
+  # Whether to protect inventory before login
+  protectInventory: true
+  # Allowed commands for unauthenticated players
+  allowedCommands:
+    - /login
+    - /register
+    - /l
+    - /reg
+  # Whether to force survival mode
+  forceSurvivalMode: true
+  # Whether to apply blindness effect
+  applyBlindness: true
+
+# Message Settings
+messages:
+  # Prefix for all messages
+  prefix: "&8[&6SimpleAuth&8] &r"
+  # Login message
+  login: "&aPlease login with /login <password>"
+  # Register message
+  register: "&aPlease register with /register <password> [email]"
+  # Successful login message
+  loginSuccess: "&aYou have been logged in successfully!"
+  # Successful registration message
+  registerSuccess: "&aYou have been registered successfully!"
+  # Already logged in message
+  alreadyLoggedIn: "&cYou are already logged in!"
+  # Already registered message
+  alreadyRegistered: "&cYou are already registered!"
+  # Not registered message
+  notRegistered: "&cYou are not registered!"
+  # Not logged in message
+  notLoggedIn: "&cYou are not logged in!"
+  # Password changed message
+  passwordChanged: "&aYour password has been changed successfully!"
+  # Logged out message
+  loggedOut: "&aYou have been logged out successfully!"
+  # Unregistered message
+  unregistered: "&aYour account has been unregistered successfully!"
+  # Reload message
+  reloaded: "&aConfiguration reloaded successfully!"
+
+# Premium (Paid Minecraft) Account Settings
+premium:
+  # Whether to enable premium (paid Minecraft) account auto-login
+  enabled: true
+  # Whether to force premium users to use their Minecraft username
+  forceUsername: true
+

--- a/SimpleAuthPlugin/src/main/resources/config.yml
+++ b/SimpleAuthPlugin/src/main/resources/config.yml
@@ -48,8 +48,6 @@ login:
   loginTimeout: 300
   # Whether to kick players on wrong password
   kickOnWrongPassword: true
-  # Message to send on wrong password
-  wrongPasswordMessage: "Wrong password!"
 
 # Session Settings
 session:
@@ -105,29 +103,51 @@ messages:
   # Prefix for all messages
   prefix: "&8[&6SimpleAuth&8] &r"
   # Login message
-  login: "&aPlease login with /login <password>"
+  login: "&6Please log in with &f/login <password>"
   # Register message
-  register: "&aPlease register with /register <password> [email]"
+  register: "&6Please register with &f/register <password> <email>"
   # Successful login message
-  loginSuccess: "&aYou have been logged in successfully!"
+  loginSuccess: "&2Login successful!"
   # Successful registration message
-  registerSuccess: "&aYou have been registered successfully!"
+  registerSuccess: "&2Registration successful!"
   # Already logged in message
   alreadyLoggedIn: "&cYou are already logged in!"
   # Already registered message
-  alreadyRegistered: "&cYou are already registered!"
+  alreadyRegistered: "&cThis username is already registered!"
   # Not registered message
-  notRegistered: "&cYou are not registered!"
+  notRegistered: "&cThis username is not registered!"
   # Not logged in message
   notLoggedIn: "&cYou are not logged in!"
   # Password changed message
-  passwordChanged: "&aYour password has been changed successfully!"
+  passwordChanged: "&2Your password has been changed successfully!"
   # Logged out message
-  loggedOut: "&aYou have been logged out successfully!"
+  loggedOut: "&2You have been logged out successfully!"
   # Unregistered message
-  unregistered: "&aYour account has been unregistered successfully!"
+  unregistered: "&2Your account has been unregistered successfully!"
   # Reload message
-  reloaded: "&aConfiguration reloaded successfully!"
+  reloaded: "&2Configuration reloaded successfully!"
+  # Wrong password message
+  wrongPassword: "&cWrong password!"
+  # Login timeout message
+  loginTimeout: "&cLogin timeout exceeded!"
+  # Session resumed message
+  sessionResumed: "&2Session resumed!"
+  # Account not activated message
+  accountNotActivated: "&cYour account is not activated yet!"
+  # Email required message
+  emailRequired: "&cEmail address is required for registration!"
+  # Invalid email message
+  invalidEmail: "&cInvalid email address!"
+  # Too many accounts message
+  tooManyAccounts: "&cYou have registered too many accounts!"
+  # Password too short message
+  passwordTooShort: "&cPassword is too short!"
+  # Password too long message
+  passwordTooLong: "&cPassword is too long!"
+  # Password unsafe message
+  passwordUnsafe: "&cThe chosen password is unsafe!"
+  # Welcome message
+  welcome: "&2Welcome to the server!"
 
 # Premium (Paid Minecraft) Account Settings
 premium:
@@ -135,4 +155,3 @@ premium:
   enabled: true
   # Whether to force premium users to use their Minecraft username
   forceUsername: true
-

--- a/SimpleAuthPlugin/src/main/resources/plugin.yml
+++ b/SimpleAuthPlugin/src/main/resources/plugin.yml
@@ -1,0 +1,72 @@
+name: SimpleAuthPlugin
+version: '${project.version}'
+main: com.simpleauth.plugin.SimpleAuthPlugin
+api-version: '1.21'
+authors: [SimpleAuthTeam]
+description: A simple authentication plugin for Minecraft servers
+website: https://github.com/SimpleAuth
+
+commands:
+  login:
+    description: Login to the server
+    usage: /login <password>
+    aliases: [l]
+  register:
+    description: Register an account
+    usage: /register <password> [email]
+    aliases: [reg]
+  changepassword:
+    description: Change your password
+    usage: /changepassword <oldPassword> <newPassword>
+    aliases: [changepw, cp]
+  logout:
+    description: Logout from the server
+    usage: /logout
+  unregister:
+    description: Unregister your account
+    usage: /unregister <password>
+  authreload:
+    description: Reload the plugin configuration
+    usage: /authreload
+    permission: simpleauth.admin.reload
+  authstatus:
+    description: Check the authentication status
+    usage: /authstatus
+    permission: simpleauth.admin.status
+
+permissions:
+  simpleauth.admin.*:
+    description: Gives access to all SimpleAuth admin commands
+    children:
+      simpleauth.admin.reload: true
+      simpleauth.admin.status: true
+      simpleauth.admin.unregister: true
+  simpleauth.admin.reload:
+    description: Allows reloading the plugin configuration
+    default: op
+  simpleauth.admin.status:
+    description: Allows checking the authentication status
+    default: op
+  simpleauth.admin.unregister:
+    description: Allows unregistering other players
+    default: op
+  simpleauth.player.*:
+    description: Gives access to all SimpleAuth player commands
+    children:
+      simpleauth.player.login: true
+      simpleauth.player.register: true
+      simpleauth.player.changepassword: true
+      simpleauth.player.logout: true
+  simpleauth.player.login:
+    description: Allows logging in
+    default: true
+  simpleauth.player.register:
+    description: Allows registering
+    default: true
+  simpleauth.player.changepassword:
+    description: Allows changing password
+    default: true
+  simpleauth.player.logout:
+    description: Allows logging out
+    default: true
+


### PR DESCRIPTION
This commit adds a complete authentication plugin based on AuthMeReloaded but with plain text password storage as requested. The plugin includes:

- Authentication system with login/register commands
- Session management
- Database support (MySQL, SQLite, YAML)
- Player protection features
- Customizable configuration